### PR TITLE
feat: add liepin-jobs skill to featured skills

### DIFF
--- a/featured-skills.json
+++ b/featured-skills.json
@@ -1,4 +1,13 @@
 {
   "updated_at": "2026-03-19T01:01:31.505Z",
-  "skills": []
+  "skills": [
+    {
+      "slug": "liepin-jobs",
+      "name": "liepin-jobs",
+      "summary": "Search jobs on Liepin (猎聘), apply to positions, view and edit resumes. Zero-dependency Python CLI wrapping Liepin's official MCP Server.",
+      "downloads": 0,
+      "stars": 0,
+      "source_url": "https://github.com/xllinbupt/MCP2skill/tree/master/liepin-jobs"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add **liepin-jobs** skill to `featured-skills.json` registry
- Liepin (猎聘) job search, resume management, and application tool
- Zero-dependency Python CLI wrapping Liepin's official MCP Server
- Source: https://github.com/xllinbupt/MCP2skill/tree/master/liepin-jobs

## Skill Details

| Field | Value |
|-------|-------|
| Slug | `liepin-jobs` |
| Name | liepin-jobs |
| Summary | Search jobs on Liepin (猎聘), apply to positions, view and edit resumes |
| Source | [xllinbupt/MCP2skill/liepin-jobs](https://github.com/xllinbupt/MCP2skill/tree/master/liepin-jobs) |
| License | MIT |
| Category | Productivity |
| Triggers | 找工作, 搜职位, 投简历, 猎聘, liepin, 求职, 招聘, 简历 |

## Test plan

- [ ] Verify `featured-skills.json` is valid JSON
- [ ] Verify the `source_url` resolves to a valid GitHub path containing SKILL.md