### PR TITLE
feat: render markdown frontmatter as metadata table

### DIFF
--- a/docs/releases/v0.4.1/plan-frontmatter-table.md
+++ b/docs/releases/v0.4.1/plan-frontmatter-table.md
@@ -1,0 +1,34 @@
+# Plan: Skill 详情页 Frontmatter 元数据表格展示
+
+## Context
+当前 `SkillDetailView` 使用 `remarkFrontmatter` 插件，该插件只是让 react-markdown 忽略 YAML frontmatter（不报错），但不会渲染它。用户希望像 GitHub 一样，将 frontmatter 中的字段以表格形式展示在 markdown 内容顶部。
+
+## 修改方案
+
+### 仅需修改 1 个文件
+**`src/components/skills/SkillDetailView.tsx`** — `FileContentRenderer` 组件
+
+### 实现步骤
+
+1. **添加 frontmatter 解析函数** — 在 `FileContentRenderer` 中，对 markdown 文件的 content 进行简单的 YAML frontmatter 提取：
+   - 检测 `---` 开头和结束标记
+   - 逐行解析 `key: value` 对，得到 `Record<string, string>`
+   - 分离出 frontmatter 数据和剩余的 markdown body
+
+2. **渲染 frontmatter 表格** — 在 `<Markdown>` 组件之前，如果存在 frontmatter 数据，渲染一个 HTML 表格：
+   - 表头为 frontmatter 的 key（如 name, description, license）
+   - 表体为对应的 value
+   - 复用现有的 `.markdown-body table/th/td` 样式（已在 App.css 中定义）
+
+3. **传递剩余内容给 Markdown** — 将去除 frontmatter 后的 body 传给 `<Markdown>` 组件，同时保留 `remarkFrontmatter` 插件（作为安全兜底）
+
+### 不需要的改动
+- 不需要安装新依赖（不用 `gray-matter` 等库，简单的字符串解析即可）
+- 不需要修改后端
+- 不需要新增 CSS（已有 table 样式）
+- 不需要 i18n（表头直接使用 frontmatter 的 key 名）
+
+## 验证
+- `npm run check` 通过
+- 打开一个包含 frontmatter 的 skill（如 SKILL.md），确认顶部显示元数据表格，下方正常渲染 markdown 内容
+- 打开没有 frontmatter 的文件，确认不会显示表格，渲染正常

--- a/src/components/skills/SkillDetailView.tsx
+++ b/src/components/skills/SkillDetailView.tsx
@@ -238,11 +238,60 @@ type FileContentRendererProps = {
   isDark: boolean
 }
 
+function parseFrontmatter(raw: string): {
+  meta: Record<string, string> | null
+  body: string
+} {
+  if (!raw.startsWith('---')) return { meta: null, body: raw }
+  const end = raw.indexOf('\n---', 3)
+  if (end === -1) return { meta: null, body: raw }
+  const block = raw.slice(4, end)
+  const entries: Record<string, string> = {}
+  for (const line of block.split('\n')) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    const key = line.slice(0, idx).trim()
+    let val = line.slice(idx + 1).trim()
+    // strip surrounding quotes
+    if (
+      val.length >= 2 &&
+      ((val[0] === '"' && val[val.length - 1] === '"') ||
+        (val[0] === "'" && val[val.length - 1] === "'"))
+    ) {
+      val = val.slice(1, -1)
+    }
+    if (key) entries[key] = val
+  }
+  const keys = Object.keys(entries)
+  if (keys.length === 0) return { meta: null, body: raw }
+  const body = raw.slice(end + 4).replace(/^\n+/, '')
+  return { meta: entries, body }
+}
+
 const FileContentRenderer = memo(
   ({ filename, content, isDark }: FileContentRendererProps) => {
     if (isMarkdown(filename)) {
+      const { meta, body } = parseFrontmatter(content)
       return (
         <div className="markdown-body">
+          {meta && (
+            <table>
+              <thead>
+                <tr>
+                  {Object.keys(meta).map((k) => (
+                    <th key={k}>{k}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {Object.values(meta).map((v, i) => (
+                    <td key={i}>{v}</td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          )}
           <Markdown
             remarkPlugins={[remarkFrontmatter, remarkGfm]}
             components={{
@@ -273,7 +322,7 @@ const FileContentRenderer = memo(
               },
             }}
           >
-            {content}
+            {body}
           </Markdown>
         </div>
       )


### PR DESCRIPTION
## Summary
- Parse YAML frontmatter from markdown files and render it as a GitHub-style table at the top of skill detail content
- Keys become column headers, values become the row beneath
- Reuses existing `.markdown-body table` styles, no new CSS or dependencies needed

## Test plan
- [x] Open a skill with frontmatter in SKILL.md, verify metadata table renders at top
- [x] Open a markdown file without frontmatter, verify no table appears and content renders normally
- [x] Verify dark/light theme compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)