### PR TITLE
chore: bump version to 0.4.1 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-21
+
+### Added
+- **Frontmatter metadata table**: Markdown files with YAML frontmatter now render a GitHub-style metadata table at the top of the skill detail view.
+
 ## [0.4.0] - 2026-03-20
 
 ### Added

--- a/docs/CHANGELOG.zh.md
+++ b/docs/CHANGELOG.zh.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-03-21
+
+### 新增
+- **Frontmatter 元数据表格**：包含 YAML frontmatter 的 Markdown 文件在技能详情页顶部以 GitHub 风格的表格展示元数据。
+
 ## [0.4.0] - 2026-03-20
 
 ### 新增

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-hub",
-  "version": "0.2.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-hub",
-      "version": "0.2.0",
+      "version": "0.4.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skills-hub",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --strictPort",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Skills Hub",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.qufei1993.skillshub",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.1 across `package.json`, `tauri.conf.json`, and `Cargo.toml`
- Add v0.4.1 changelog entries (EN & ZH) for frontmatter metadata table feature

## Test plan
- [x] `npm run version:check` passes
- [x] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)