### PR TITLE
fix: exit app on window close instead of hiding to background

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,19 +110,11 @@ pub fn run() {
             commands::cancel_current_operation
         ])
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                let _ = window.hide();
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                window.app_handle().exit(0);
             }
         })
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
-        .run(|app, event| {
-            if matches!(event, tauri::RunEvent::Resumed) {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
-            }
-        });
+        .run(|_app, _event| {});
 }


### PR DESCRIPTION
 ## Problem

  Closing the Skills Hub window leaves multiple orphan processes running (WebView2 renderer, GPU process, network
  process, etc.) because the `CloseRequested` event is intercepted and the window is only hidden. Since there is no
  system tray icon, users have no way to quit the app without manually killing processes in Task Manager.

  ## Fix

  Replace `api.prevent_close()` + `window.hide()` with `window.app_handle().exit(0)` so the app exits cleanly when the
  window is closed. Also removed the `RunEvent::Resumed` handler which was only needed for the hide/show pattern.

  ## Testing

  - Windows 11: confirmed all Skills Hub processes terminate after closing the window