### PR TITLE
feat: discover Claude Code plugin skills

### DIFF
--- a/docs/releases/v0.6.2/minor-updates.md
+++ b/docs/releases/v0.6.2/minor-updates.md
@@ -21,3 +21,12 @@
 - 英文和中文工具支持列表已同步补充 CodeWhale。
 - 增加 Rust 测试，覆盖工具标识、全局目录、检测目录和项目目录。
 - 实现验证：`npm run check`。
+
+### 自动发现 Claude Code 插件中的 Skills
+
+- 支持读取 Claude Code 的已安装插件清单，自动发现用户级插件中包含的 Skills（Issue [#69](https://github.com/qufei1993/skills-hub/issues/69)）。
+- 支持插件根目录、标准 `skills/` 目录，以及 `.claude-plugin/plugin.json` 声明的自定义 Skill 路径。
+- 项目级插件暂不纳入自动发现，避免将只对特定项目生效的 Skill 错误导入为全局托管项。
+- 发现结果会显示插件名称和版本，并继续由用户审核选择后导入。
+- 按真实路径去重，并拒绝插件根目录之外的声明路径，避免重复条目和越界扫描。
+- 实现验证：`npm run check`。

--- a/src-tauri/src/core/onboarding.rs
+++ b/src-tauri/src/core/onboarding.rs
@@ -1,8 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::central_repo::resolve_central_repo_path;
 use super::content_hash::hash_dir;
@@ -17,6 +18,9 @@ pub struct OnboardingVariant {
     pub fingerprint: Option<String>,
     pub is_link: bool,
     pub link_target: Option<PathBuf>,
+    pub plugin_name: Option<String>,
+    pub plugin_version: Option<String>,
+    pub plugin_scope: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -40,29 +44,62 @@ pub fn build_onboarding_plan<R: tauri::Runtime>(
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("failed to resolve home directory"))?;
     let central = resolve_central_repo_path(app, store)?;
-    let managed_targets = store
+    let mut managed_targets = store
         .list_all_skill_target_paths()
         .unwrap_or_default()
         .into_iter()
         .map(|(tool, path)| managed_target_key(&tool, Path::new(&path)))
         .collect::<std::collections::HashSet<_>>();
-    build_onboarding_plan_in_home(&home, Some(&central), Some(&managed_targets))
+    for skill in store.list_skills().unwrap_or_default() {
+        if let Some(source_ref) = skill.source_ref {
+            managed_targets.insert(managed_target_key(
+                CLAUDE_PLUGIN_TOOL_KEY,
+                Path::new(&source_ref),
+            ));
+        }
+    }
+    let claude_config_dir = resolve_claude_config_dir(&home);
+    build_onboarding_plan_with_claude_dir(
+        &home,
+        &claude_config_dir,
+        Some(&central),
+        Some(&managed_targets),
+    )
 }
 
+#[cfg(test)]
 fn build_onboarding_plan_in_home(
     home: &Path,
+    exclude_root: Option<&Path>,
+    exclude_managed_targets: Option<&std::collections::HashSet<String>>,
+) -> Result<OnboardingPlan> {
+    build_onboarding_plan_with_claude_dir(
+        home,
+        &home.join(".claude"),
+        exclude_root,
+        exclude_managed_targets,
+    )
+}
+
+fn build_onboarding_plan_with_claude_dir(
+    home: &Path,
+    claude_config_dir: &Path,
     exclude_root: Option<&Path>,
     exclude_managed_targets: Option<&std::collections::HashSet<String>>,
 ) -> Result<OnboardingPlan> {
     let adapters = default_tool_adapters();
     let mut all_detected: Vec<DetectedSkill> = Vec::new();
     let mut scanned = 0usize;
+    let mut scanned_claude = false;
 
     for adapter in &adapters {
         if !home.join(adapter.relative_detect_dir).exists() {
             continue;
         }
         scanned += 1;
+        if adapter.id.as_key() == "claude_code" {
+            scanned_claude = true;
+        }
         let dir = home.join(adapter.relative_skills_dir);
         let detected = scan_tool_dir(adapter, &dir)?;
         all_detected.extend(filter_detected(
@@ -83,7 +120,46 @@ fn build_onboarding_plan_in_home(
             fingerprint,
             is_link: skill.is_link,
             link_target: skill.link_target.clone(),
+            plugin_name: None,
+            plugin_version: None,
+            plugin_scope: None,
         });
+    }
+
+    let mut seen_source_paths = all_detected
+        .iter()
+        .filter_map(|skill| fs::canonicalize(&skill.path).ok())
+        .collect::<HashSet<_>>();
+    let plugin_variants = discover_claude_plugin_skills(claude_config_dir)
+        .into_iter()
+        .filter(|variant| {
+            let canonical_path =
+                fs::canonicalize(&variant.path).unwrap_or_else(|_| variant.path.clone());
+            if !seen_source_paths.insert(canonical_path) {
+                return false;
+            }
+            if let Some(exclude_root) = exclude_root {
+                if is_under(&variant.path, exclude_root) {
+                    return false;
+                }
+            }
+            if let Some(exclude) = exclude_managed_targets {
+                if exclude.contains(&managed_target_key(&variant.tool, &variant.path)) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect::<Vec<_>>();
+    if !plugin_variants.is_empty() && !scanned_claude {
+        scanned += 1;
+    }
+    let plugin_skill_count = plugin_variants.len();
+    for variant in plugin_variants {
+        grouped
+            .entry(variant.name.clone())
+            .or_default()
+            .push(variant);
     }
 
     let groups: Vec<OnboardingGroup> = grouped
@@ -107,9 +183,191 @@ fn build_onboarding_plan_in_home(
 
     Ok(OnboardingPlan {
         total_tools_scanned: scanned,
-        total_skills_found: all_detected.len(),
+        total_skills_found: all_detected.len() + plugin_skill_count,
         groups,
     })
+}
+
+const CLAUDE_PLUGIN_TOOL_KEY: &str = "claude_code_plugin";
+
+#[derive(Debug, Deserialize)]
+struct ClaudePluginRegistry {
+    #[serde(default)]
+    plugins: HashMap<String, Vec<ClaudePluginInstall>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaudePluginInstall {
+    #[serde(default)]
+    scope: String,
+    install_path: Option<PathBuf>,
+    version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudePluginManifest {
+    skills: Option<ClaudePluginSkillPaths>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ClaudePluginSkillPaths {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl ClaudePluginSkillPaths {
+    fn paths(self) -> Vec<String> {
+        match self {
+            Self::One(path) => vec![path],
+            Self::Many(paths) => paths,
+        }
+    }
+}
+
+fn resolve_claude_config_dir(home: &Path) -> PathBuf {
+    let Some(value) = std::env::var_os("CLAUDE_CONFIG_DIR") else {
+        return home.join(".claude");
+    };
+    let path = PathBuf::from(value);
+    if let Ok(relative) = path.strip_prefix("~") {
+        return home.join(relative);
+    }
+    path
+}
+
+fn discover_claude_plugin_skills(claude_config_dir: &Path) -> Vec<OnboardingVariant> {
+    let registry_path = claude_config_dir.join("plugins/installed_plugins.json");
+    let Ok(content) = fs::read_to_string(&registry_path) else {
+        return Vec::new();
+    };
+    let registry: ClaudePluginRegistry = match serde_json::from_str(&content) {
+        Ok(registry) => registry,
+        Err(err) => {
+            log::warn!(
+                "[onboarding] failed to parse Claude plugin registry {:?}: {}",
+                registry_path,
+                err
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut variants = Vec::new();
+    let mut seen_paths = HashSet::new();
+    for (plugin_name, installs) in registry.plugins {
+        for install in installs {
+            if install.scope != "user" {
+                continue;
+            }
+            let Some(install_path) = install.install_path else {
+                continue;
+            };
+            let Ok(plugin_root) = fs::canonicalize(install_path) else {
+                continue;
+            };
+            if !plugin_root.is_dir() {
+                continue;
+            }
+
+            let mut candidates = Vec::new();
+            add_skill_dir_candidate(&plugin_root, &plugin_root, &mut candidates);
+            add_child_skill_candidates(&plugin_root.join("skills"), &plugin_root, &mut candidates);
+            for declared_path in read_declared_plugin_skill_paths(&plugin_root) {
+                add_declared_skill_candidates(
+                    &plugin_root.join(declared_path),
+                    &plugin_root,
+                    &mut candidates,
+                );
+            }
+
+            for candidate in candidates {
+                let Ok(canonical_path) = fs::canonicalize(&candidate) else {
+                    continue;
+                };
+                if !seen_paths.insert(canonical_path.clone()) {
+                    continue;
+                }
+                let name = if canonical_path == plugin_root {
+                    plugin_name
+                        .split_once('@')
+                        .map_or_else(|| plugin_name.clone(), |(name, _)| name.to_string())
+                } else {
+                    let Some(name) = canonical_path
+                        .file_name()
+                        .map(|value| value.to_string_lossy().to_string())
+                    else {
+                        continue;
+                    };
+                    name
+                };
+                variants.push(OnboardingVariant {
+                    tool: CLAUDE_PLUGIN_TOOL_KEY.to_string(),
+                    name,
+                    fingerprint: hash_dir(&canonical_path).ok(),
+                    path: canonical_path,
+                    is_link: false,
+                    link_target: None,
+                    plugin_name: Some(plugin_name.clone()),
+                    plugin_version: install.version.clone(),
+                    plugin_scope: Some(install.scope.clone()),
+                });
+            }
+        }
+    }
+    variants
+}
+
+fn read_declared_plugin_skill_paths(plugin_root: &Path) -> Vec<String> {
+    let path = plugin_root.join(".claude-plugin/plugin.json");
+    let Ok(content) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    serde_json::from_str::<ClaudePluginManifest>(&content)
+        .ok()
+        .and_then(|manifest| manifest.skills)
+        .map(ClaudePluginSkillPaths::paths)
+        .unwrap_or_default()
+}
+
+fn add_declared_skill_candidates(path: &Path, plugin_root: &Path, out: &mut Vec<PathBuf>) {
+    if path.file_name().is_some_and(|name| name == "SKILL.md") {
+        if let Some(parent) = path.parent() {
+            add_skill_dir_candidate(parent, plugin_root, out);
+        }
+        return;
+    }
+    if add_skill_dir_candidate(path, plugin_root, out) {
+        return;
+    }
+    add_child_skill_candidates(path, plugin_root, out);
+}
+
+fn add_child_skill_candidates(path: &Path, plugin_root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        add_skill_dir_candidate(&entry.path(), plugin_root, out);
+    }
+}
+
+fn add_skill_dir_candidate(path: &Path, plugin_root: &Path, out: &mut Vec<PathBuf>) -> bool {
+    let Ok(canonical_root) = fs::canonicalize(plugin_root) else {
+        return false;
+    };
+    let Ok(canonical_path) = fs::canonicalize(path) else {
+        return false;
+    };
+    if !canonical_path.starts_with(canonical_root)
+        || !canonical_path.is_dir()
+        || !canonical_path.join("SKILL.md").is_file()
+    {
+        return false;
+    }
+    out.push(path.to_path_buf());
+    true
 }
 
 fn filter_detected(

--- a/src-tauri/src/core/tests/onboarding.rs
+++ b/src-tauri/src/core/tests/onboarding.rs
@@ -68,3 +68,256 @@ fn excludes_managed_skill_targets() {
     let plan = build_onboarding_plan_in_home(home.path(), None, Some(&exclude)).unwrap();
     assert_eq!(plan.total_skills_found, 0);
 }
+
+#[test]
+fn discovers_user_scoped_claude_plugin_skills() {
+    let home = tempfile::tempdir().unwrap();
+    let claude_dir = home.path().join(".claude");
+    let plugins_dir = claude_dir.join("plugins");
+    let standard_plugin = plugins_dir.join("cache/official/standard/1.0.0");
+    let custom_plugin = plugins_dir.join("cache/community/custom/2.0.0");
+    let root_plugin = plugins_dir.join("cache/community/root/3.0.0");
+    let project_plugin = plugins_dir.join("cache/official/project-only/1.0.0");
+
+    fs::create_dir_all(standard_plugin.join("skills/standard-skill")).unwrap();
+    fs::write(
+        standard_plugin.join("skills/standard-skill/SKILL.md"),
+        "# Standard",
+    )
+    .unwrap();
+
+    fs::create_dir_all(custom_plugin.join("custom/custom-skill")).unwrap();
+    fs::write(
+        custom_plugin.join("custom/custom-skill/SKILL.md"),
+        "# Custom",
+    )
+    .unwrap();
+    fs::create_dir_all(custom_plugin.join(".claude-plugin")).unwrap();
+    fs::write(
+        custom_plugin.join(".claude-plugin/plugin.json"),
+        r#"{"skills":["./custom/custom-skill"]}"#,
+    )
+    .unwrap();
+
+    fs::create_dir_all(&root_plugin).unwrap();
+    fs::write(root_plugin.join("SKILL.md"), "# Root").unwrap();
+
+    fs::create_dir_all(project_plugin.join("skills/project-skill")).unwrap();
+    fs::write(
+        project_plugin.join("skills/project-skill/SKILL.md"),
+        "# Project",
+    )
+    .unwrap();
+
+    fs::create_dir_all(&plugins_dir).unwrap();
+    fs::write(
+        plugins_dir.join("installed_plugins.json"),
+        format!(
+            r#"{{
+              "version": 2,
+              "plugins": {{
+                "standard@official": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "1.0.0"
+                }}],
+                "custom@community": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "2.0.0"
+                }}],
+                "root@community": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "3.0.0"
+                }}],
+                "broken@community": [{{
+                  "scope": "user",
+                  "version": "1.0.0"
+                }}],
+                "project-only@official": [{{
+                  "scope": "project",
+                  "projectPath": "/tmp/project",
+                  "installPath": "{}",
+                  "version": "1.0.0"
+                }}]
+              }}
+            }}"#,
+            standard_plugin.display(),
+            custom_plugin.display(),
+            root_plugin.display(),
+            project_plugin.display()
+        ),
+    )
+    .unwrap();
+
+    let plan = build_onboarding_plan_in_home(home.path(), None, None).unwrap();
+    assert_eq!(plan.total_tools_scanned, 1);
+    assert_eq!(plan.total_skills_found, 3);
+
+    let standard = plan
+        .groups
+        .iter()
+        .find(|group| group.name == "standard-skill")
+        .unwrap();
+    assert_eq!(
+        standard.variants[0].plugin_name.as_deref(),
+        Some("standard@official")
+    );
+    assert_eq!(
+        standard.variants[0].plugin_version.as_deref(),
+        Some("1.0.0")
+    );
+    assert_eq!(standard.variants[0].plugin_scope.as_deref(), Some("user"));
+
+    let custom = plan
+        .groups
+        .iter()
+        .find(|group| group.name == "custom-skill")
+        .unwrap();
+    assert_eq!(
+        custom.variants[0].plugin_name.as_deref(),
+        Some("custom@community")
+    );
+    assert_eq!(
+        custom.variants[0].path,
+        fs::canonicalize(custom_plugin.join("custom/custom-skill")).unwrap()
+    );
+    let root = plan
+        .groups
+        .iter()
+        .find(|group| group.name == "root")
+        .unwrap();
+    assert_eq!(
+        root.variants[0].plugin_name.as_deref(),
+        Some("root@community")
+    );
+    assert!(plan
+        .groups
+        .iter()
+        .all(|group| group.name != "project-skill"));
+}
+
+#[test]
+fn ignores_duplicate_and_escaping_claude_plugin_skill_paths() {
+    let home = tempfile::tempdir().unwrap();
+    let plugins_dir = home.path().join(".claude/plugins");
+    let plugin = plugins_dir.join("cache/community/demo/1.0.0");
+    let outside = home.path().join("outside-skill");
+
+    fs::create_dir_all(plugin.join("skills/demo")).unwrap();
+    fs::write(plugin.join("skills/demo/SKILL.md"), "# Demo").unwrap();
+    fs::create_dir_all(plugin.join(".claude-plugin")).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("SKILL.md"), "# Outside").unwrap();
+    fs::write(
+        plugin.join(".claude-plugin/plugin.json"),
+        r#"{"skills":["./skills/demo","../../../../../outside-skill"]}"#,
+    )
+    .unwrap();
+
+    fs::create_dir_all(&plugins_dir).unwrap();
+    fs::write(
+        plugins_dir.join("installed_plugins.json"),
+        format!(
+            r#"{{
+              "version": 2,
+              "plugins": {{
+                "demo@community": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "1.0.0"
+                }}]
+              }}
+            }}"#,
+            plugin.display()
+        ),
+    )
+    .unwrap();
+
+    let plan = build_onboarding_plan_in_home(home.path(), None, None).unwrap();
+    assert_eq!(plan.total_skills_found, 1);
+    assert_eq!(plan.groups[0].name, "demo");
+    assert_eq!(plan.groups[0].variants.len(), 1);
+}
+
+#[test]
+#[cfg(unix)]
+fn deduplicates_plugin_skill_already_present_in_claude_skills() {
+    use std::os::unix::fs::symlink;
+
+    let home = tempfile::tempdir().unwrap();
+    let plugins_dir = home.path().join(".claude/plugins");
+    let plugin = plugins_dir.join("cache/community/demo/1.0.0");
+    let plugin_skill = plugin.join("skills/demo");
+
+    fs::create_dir_all(&plugin_skill).unwrap();
+    fs::write(plugin_skill.join("SKILL.md"), "# Demo").unwrap();
+    fs::create_dir_all(home.path().join(".claude/skills")).unwrap();
+    symlink(&plugin_skill, home.path().join(".claude/skills/demo")).unwrap();
+
+    fs::create_dir_all(&plugins_dir).unwrap();
+    fs::write(
+        plugins_dir.join("installed_plugins.json"),
+        format!(
+            r#"{{
+              "version": 2,
+              "plugins": {{
+                "demo@community": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "1.0.0"
+                }}]
+              }}
+            }}"#,
+            plugin.display()
+        ),
+    )
+    .unwrap();
+
+    let plan = build_onboarding_plan_in_home(home.path(), None, None).unwrap();
+    assert_eq!(plan.total_skills_found, 1);
+    assert_eq!(plan.groups.len(), 1);
+    assert_eq!(plan.groups[0].variants.len(), 1);
+    assert_eq!(plan.groups[0].variants[0].tool, "claude_code");
+}
+
+#[test]
+fn excludes_already_imported_claude_plugin_skill_source() {
+    let home = tempfile::tempdir().unwrap();
+    let plugins_dir = home.path().join(".claude/plugins");
+    let plugin = plugins_dir.join("cache/community/demo/1.0.0");
+    let plugin_skill = plugin.join("skills/demo");
+
+    fs::create_dir_all(&plugin_skill).unwrap();
+    fs::write(plugin_skill.join("SKILL.md"), "# Demo").unwrap();
+    fs::create_dir_all(&plugins_dir).unwrap();
+    fs::write(
+        plugins_dir.join("installed_plugins.json"),
+        format!(
+            r#"{{
+              "version": 2,
+              "plugins": {{
+                "demo@community": [{{
+                  "scope": "user",
+                  "installPath": "{}",
+                  "version": "1.0.0"
+                }}]
+              }}
+            }}"#,
+            plugin.display()
+        ),
+    )
+    .unwrap();
+
+    let canonical_skill = fs::canonicalize(plugin_skill).unwrap();
+    let mut exclude = std::collections::HashSet::new();
+    exclude.insert(super::managed_target_key(
+        super::CLAUDE_PLUGIN_TOOL_KEY,
+        &canonical_skill,
+    ));
+
+    let plan = build_onboarding_plan_in_home(home.path(), None, Some(&exclude)).unwrap();
+    assert_eq!(plan.total_skills_found, 0);
+    assert!(plan.groups.is_empty());
+}

--- a/src/components/skills/modals/ImportModal.tsx
+++ b/src/components/skills/modals/ImportModal.tsx
@@ -35,7 +35,12 @@ const ImportModal = ({
     return plan.groups.filter((group) => {
       const fields = [
         group.name,
-        ...group.variants.flatMap((variant) => [variant.path, variant.tool]),
+        ...group.variants.flatMap((variant) => [
+          variant.path,
+          variant.tool,
+          variant.plugin_name ?? '',
+          variant.plugin_version ?? '',
+        ]),
       ]
       return fields.some((value) => value.toLowerCase().includes(normalizedQuery))
     })
@@ -126,38 +131,51 @@ const ImportModal = ({
                   )}
                 </div>
                 <div className="group-variants">
-                  {group.variants.map((variant) => (
-                    <div
-                      className="variant-row"
-                      key={`${group.name}-${variant.tool}-${variant.path}`}
-                    >
-                      {group.has_conflict ? (
-                        <input
-                          type="radio"
-                          name={`variant-${group.name}`}
-                          checked={variantChoice[group.name] === variant.path}
-                          onChange={() => onSelectVariant(group.name, variant.path)}
-                        />
-                      ) : (
-                        <span className="variant-spacer" />
-                      )}
-                      <div className="variant-info">
-                        <span className="path">{variant.path}</span>
-                        <span className="found-pill">
-                          {t('foundIn')} {variant.tool}
-                        </span>
+                  {group.variants.map((variant) => {
+                    const sourceLabel = variant.plugin_name
+                      ? variant.plugin_version
+                        ? t('claudePluginSourceWithVersion', {
+                            plugin: variant.plugin_name,
+                            version: variant.plugin_version,
+                          })
+                        : t('claudePluginSource', {
+                            plugin: variant.plugin_name,
+                          })
+                      : `${t('foundIn')} ${variant.tool}`
+
+                    return (
+                      <div
+                        className="variant-row"
+                        key={`${group.name}-${variant.tool}-${variant.path}`}
+                      >
+                        {group.has_conflict ? (
+                          <input
+                            type="radio"
+                            name={`variant-${group.name}`}
+                            checked={variantChoice[group.name] === variant.path}
+                            onChange={() =>
+                              onSelectVariant(group.name, variant.path)
+                            }
+                          />
+                        ) : (
+                          <span className="variant-spacer" />
+                        )}
+                        <div className="variant-info">
+                          <span className="path">{variant.path}</span>
+                          <span className="found-pill">{sourceLabel}</span>
+                        </div>
+                        {variant.is_link ? (
+                          <span className="meta">
+                            {t('linkLabel', {
+                              target: variant.link_target ?? t('unknown'),
+                            })}
+                          </span>
+                        ) : (
+                          <span className="meta">{t('directory')}</span>
+                        )}
                       </div>
-                      {variant.is_link ? (
-                        <span className="meta">
-                          {t('linkLabel', {
-                            target: variant.link_target ?? t('unknown'),
-                          })}
-                        </span>
-                      ) : (
-                        <span className="meta">{t('directory')}</span>
-                      )}
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               </div>
             ))}

--- a/src/components/skills/types.ts
+++ b/src/components/skills/types.ts
@@ -5,6 +5,9 @@ export type OnboardingVariant = {
   fingerprint?: string | null
   is_link: boolean
   link_target?: string | null
+  plugin_name?: string | null
+  plugin_version?: string | null
+  plugin_scope?: string | null
 }
 
 export type OnboardingGroup = {

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -231,6 +231,9 @@ export const resources = {
       toolsScanned: 'Tools scanned: {{count}}',
       skillsFound: 'Skills found: {{count}}',
       foundIn: 'Found in',
+      claudePluginSource: 'Claude Code plugin · {{plugin}} · User',
+      claudePluginSourceWithVersion:
+        'Claude Code plugin · {{plugin}} · v{{version}} · User',
       errors: {
         notTauri: 'Current environment is not Tauri. Please run `npm run tauri dev`.',
         skillExistsInHub: 'This skill already exists in Hub. No need to install again.',
@@ -602,6 +605,9 @@ export const resources = {
       toolsScanned: '已扫描工具数：{{count}}',
       skillsFound: '发现 Skills 数：{{count}}',
       foundIn: '发现于',
+      claudePluginSource: 'Claude Code 插件 · {{plugin}} · 用户级',
+      claudePluginSourceWithVersion:
+        'Claude Code 插件 · {{plugin}} · v{{version}} · 用户级',
       errors: {
         notTauri: '当前环境不是 Tauri，请用 `npm run tauri dev` 启动应用。',
         skillExistsInHub: '该 Skill 已存在于 Hub，无需重复安装。',


### PR DESCRIPTION
## Summary
- discover portable Skills from Claude Code user-scoped installed plugins
- support plugin-root Skills, standard `skills/` directories, and paths declared in `.claude-plugin/plugin.json`
- show plugin name and version in the existing import review modal
- ignore project-scoped plugins, unsafe paths, duplicate sources, and already imported plugin Skills
- document the feature in the v0.6.2 release notes

## Verification
- `npm run check`
- 95 Rust tests passed

Closes #69