### PR TITLE
fix: support batch install for local skill dirs and fix modal overlap

### DIFF
--- a/src-tauri/src/core/installer.rs
+++ b/src-tauri/src/core/installer.rs
@@ -1038,7 +1038,7 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
         }
     }
 
-    // Also scan root-level directories for skills (matching collect_skill_dirs behavior)
+    // Also scan root-level directories for skills (matching collect_skill_dirs behavior).
     // This handles the case where the user selects a directory that directly contains
     // skill subdirectories (e.g. a "skills" directory with article-writer/SKILL.md).
     if let Ok(rd) = std::fs::read_dir(base_path) {
@@ -1079,7 +1079,7 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
                     }
                 }
             } else if is_skill_container_dir_name(&dir_name) {
-                // Scan children of skill container directories
+                // Scan children of skill container directories.
                 if let Ok(sub_rd) = std::fs::read_dir(&p) {
                     for sub_entry in sub_rd.flatten() {
                         let sub_p = sub_entry.path();
@@ -1104,10 +1104,7 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
                                 }
                                 Err(reason) => {
                                     out.push(LocalSkillCandidate {
-                                        name: sub_entry
-                                            .file_name()
-                                            .to_string_lossy()
-                                            .to_string(),
+                                        name: sub_entry.file_name().to_string_lossy().to_string(),
                                         description: None,
                                         subpath: sub_rel,
                                         valid: false,
@@ -1116,10 +1113,7 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
                                 }
                             }
                         } else if is_claude_skill_dir(&sub_p) {
-                            let name = sub_entry
-                                .file_name()
-                                .to_string_lossy()
-                                .to_string();
+                            let name = sub_entry.file_name().to_string_lossy().to_string();
                             let desc = read_plugin_description(base_path);
                             out.push(LocalSkillCandidate {
                                 name,
@@ -1130,10 +1124,7 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
                             });
                         } else {
                             out.push(LocalSkillCandidate {
-                                name: sub_entry
-                                    .file_name()
-                                    .to_string_lossy()
-                                    .to_string(),
+                                name: sub_entry.file_name().to_string_lossy().to_string(),
                                 description: None,
                                 subpath: sub_rel,
                                 valid: false,

--- a/src-tauri/src/core/installer.rs
+++ b/src-tauri/src/core/installer.rs
@@ -1038,6 +1038,114 @@ pub fn list_local_skills(base_path: &Path) -> Result<Vec<LocalSkillCandidate>> {
         }
     }
 
+    // Also scan root-level directories for skills (matching collect_skill_dirs behavior)
+    // This handles the case where the user selects a directory that directly contains
+    // skill subdirectories (e.g. a "skills" directory with article-writer/SKILL.md).
+    if let Ok(rd) = std::fs::read_dir(base_path) {
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if !p.is_dir() {
+                continue;
+            }
+            let dir_name = entry.file_name();
+            let dir_name = dir_name.to_string_lossy();
+            if is_hidden_dir_name(&dir_name) || is_known_root_scan_dir(&dir_name) {
+                continue;
+            }
+            let rel = p
+                .strip_prefix(base_path)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .to_string();
+            if p.join("SKILL.md").exists() {
+                match parse_skill_md_with_reason(&p.join("SKILL.md")) {
+                    Ok((name, desc)) => {
+                        out.push(LocalSkillCandidate {
+                            name,
+                            description: desc,
+                            subpath: rel,
+                            valid: true,
+                            reason: None,
+                        });
+                    }
+                    Err(reason) => {
+                        out.push(LocalSkillCandidate {
+                            name: dir_name.to_string(),
+                            description: None,
+                            subpath: rel,
+                            valid: false,
+                            reason: Some(reason.to_string()),
+                        });
+                    }
+                }
+            } else if is_skill_container_dir_name(&dir_name) {
+                // Scan children of skill container directories
+                if let Ok(sub_rd) = std::fs::read_dir(&p) {
+                    for sub_entry in sub_rd.flatten() {
+                        let sub_p = sub_entry.path();
+                        if !sub_p.is_dir() {
+                            continue;
+                        }
+                        let sub_rel = sub_p
+                            .strip_prefix(base_path)
+                            .unwrap_or(&sub_p)
+                            .to_string_lossy()
+                            .to_string();
+                        if sub_p.join("SKILL.md").exists() {
+                            match parse_skill_md_with_reason(&sub_p.join("SKILL.md")) {
+                                Ok((name, desc)) => {
+                                    out.push(LocalSkillCandidate {
+                                        name,
+                                        description: desc,
+                                        subpath: sub_rel,
+                                        valid: true,
+                                        reason: None,
+                                    });
+                                }
+                                Err(reason) => {
+                                    out.push(LocalSkillCandidate {
+                                        name: sub_entry
+                                            .file_name()
+                                            .to_string_lossy()
+                                            .to_string(),
+                                        description: None,
+                                        subpath: sub_rel,
+                                        valid: false,
+                                        reason: Some(reason.to_string()),
+                                    });
+                                }
+                            }
+                        } else if is_claude_skill_dir(&sub_p) {
+                            let name = sub_entry
+                                .file_name()
+                                .to_string_lossy()
+                                .to_string();
+                            let desc = read_plugin_description(base_path);
+                            out.push(LocalSkillCandidate {
+                                name,
+                                description: desc,
+                                subpath: sub_rel,
+                                valid: true,
+                                reason: None,
+                            });
+                        } else {
+                            out.push(LocalSkillCandidate {
+                                name: sub_entry
+                                    .file_name()
+                                    .to_string_lossy()
+                                    .to_string(),
+                                description: None,
+                                subpath: sub_rel,
+                                valid: false,
+                                reason: Some("missing_skill_md".to_string()),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     out.sort_by(|a, b| a.name.cmp(&b.name));
     out.dedup_by(|a, b| a.subpath == b.subpath);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1030,6 +1030,7 @@ function App() {
     setGitCandidates([])
     setGitCandidateSelected({})
     setGitCandidatesRepoUrl('')
+    setShowAddModal(true)
   }, [loading])
 
   const handleCloseLocalPick = useCallback(() => {
@@ -1042,6 +1043,7 @@ function App() {
     setLocalCandidates([])
     setLocalCandidateSelected({})
     setLocalCandidatesBasePath('')
+    setShowAddModal(true)
   }, [loading])
 
   const handleSortChange = useCallback((value: 'updated' | 'name') => {
@@ -1555,6 +1557,7 @@ function App() {
         setLocalCandidateSelected(
           Object.fromEntries(candidates.map((c) => [c.subpath, c.valid])),
         )
+        setShowAddModal(false)
         setShowLocalPickModal(true)
         setActionMessage(null)
         setLoading(false)
@@ -1596,6 +1599,7 @@ function App() {
           setGitCandidateSelected(
             Object.fromEntries(candidates.map((c) => [c.subpath, true])),
           )
+          setShowAddModal(false)
           setShowGitPickModal(true)
           setActionMessage(null)
           setLoading(false)
@@ -1677,6 +1681,7 @@ function App() {
             setGitCandidateSelected(
               Object.fromEntries(candidates.map((c) => [c.subpath, true])),
             )
+            setShowAddModal(false)
             setShowGitPickModal(true)
             setActionMessage(null)
             setLoading(false)
@@ -1689,6 +1694,7 @@ function App() {
           setGitCandidateSelected(
             Object.fromEntries(candidates.map((c) => [c.subpath, true])),
           )
+          setShowAddModal(false)
           setShowGitPickModal(true)
           setActionMessage(null)
           setLoading(false)

--- a/src/components/skills/modals/GitPickModal.tsx
+++ b/src/components/skills/modals/GitPickModal.tsx
@@ -51,7 +51,7 @@ const GitPickModal = ({
 
   return (
     <div className="modal-backdrop" onClick={onRequestClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal add-skill-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <div className="modal-title">{t('gitPickTitle')}</div>
           <button

--- a/src/components/skills/modals/LocalPickModal.tsx
+++ b/src/components/skills/modals/LocalPickModal.tsx
@@ -62,7 +62,7 @@ const LocalPickModal = ({
 
   return (
     <div className="modal-backdrop" onClick={onRequestClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal add-skill-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <div className="modal-title">{t('localPickTitle')}</div>
           <button


### PR DESCRIPTION
## Changes

### 1. Batch selection for local directory installs

`list_local_skills` previously only scanned known subdirectories (`skills/`, `.claude/skills/`, etc.), missing root-level directories that directly contain SKILL.md. When users selected a directory that itself is a skills container (e.g. `/path/to/skills` with `article-writer/SKILL.md`), zero candidates were found.

Added root-level directory scanning matching `collect_skill_dirs` behavior used by the Git install flow, so local directories now properly discover multiple skills and show the batch pick modal.

### 2. Consistent modal height

`LocalPickModal` and `GitPickModal` now use the `add-skill-modal` CSS class, giving them the same `max-height` flex layout and scrollable body as `AddSkillModal`.

### 3. Fix overlapping modals

Previously the Pick modal opened on top of the Add modal (both rendered simultaneously). Changed to a wizard-style step transition:
- Pick modal opens → Add modal closes
- Cancel on Pick → Add modal reopens (path preserved for retry)
- Close (X) → both dismissed
- Install → both closed

## Files changed

- `src-tauri/src/core/installer.rs` — add root-level scanning to `list_local_skills`
- `src/App.tsx` — modal state transition logic
- `src/components/skills/modals/LocalPickModal.tsx` — add `add-skill-modal` class
- `src/components/skills/modals/GitPickModal.tsx` — add `add-skill-modal` class

🤖 Generated with [Claude Code](https://claude.com/claude-code)