### PR TITLE
fix: update Antigravity skills path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Antigravity global sync path**: Updated Antigravity 2.0 global skill sync to `~/.gemini/config/skills` so synced skills are discovered by current Antigravity versions ([#79](https://github.com/qufei1993/skills-hub/issues/79)).
+
 ## [0.6.2] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Project skills dirs are relative to the selected project root. Tools marked `N/A
 | `claude_code` | Claude Code | `.claude/skills` | `.claude/skills` | `.claude` |
 | `codex` | Codex | `.codex/skills` | `.agents/skills` | `.codex` |
 | `opencode` | OpenCode | `.config/opencode/skills` | `.agents/skills` | `.config/opencode` |
-| `antigravity` | Antigravity | `.gemini/antigravity/skills` | `.agents/skills` | `.gemini/antigravity` |
+| `antigravity` | Antigravity | `.gemini/config/skills` | `.agents/skills` | `.gemini/config` |
 | `amp` | Amp | `.config/agents/skills` | `.agents/skills` | `.config/agents` |
 | `kimi_cli` | Kimi Code CLI | `.config/agents/skills` | `.agents/skills` | `.config/agents` |
 | `augment` | Augment | `.augment/skills` | `.augment/skills` | `.augment` |

--- a/docs/CHANGELOG.zh.md
+++ b/docs/CHANGELOG.zh.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### 修复
+- **Antigravity 全局同步路径**：将 Antigravity 2.0 的全局 Skill 同步目录更新为 `~/.gemini/config/skills`，确保当前版本 Antigravity 可以发现已同步的 Skill（[#79](https://github.com/qufei1993/skills-hub/issues/79)）。
+
 ## [0.6.2] - 2026-06-19
 
 ### 新增

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -40,7 +40,7 @@
 | `claude_code` | Claude Code | `.claude/skills` | `.claude/skills` | `.claude` |
 | `codex` | Codex | `.codex/skills` | `.agents/skills` | `.codex` |
 | `opencode` | OpenCode | `.config/opencode/skills` | `.agents/skills` | `.config/opencode` |
-| `antigravity` | Antigravity | `.gemini/antigravity/skills` | `.agents/skills` | `.gemini/antigravity` |
+| `antigravity` | Antigravity | `.gemini/config/skills` | `.agents/skills` | `.gemini/config` |
 | `amp` | Amp | `.config/agents/skills` | `.agents/skills` | `.config/agents` |
 | `kimi_cli` | Kimi Code CLI | `.config/agents/skills` | `.agents/skills` | `.config/agents` |
 | `augment` | Augment | `.augment/skills` | `.augment/skills` | `.augment` |

--- a/docs/releases/v0.6.3/minor-updates.md
+++ b/docs/releases/v0.6.3/minor-updates.md
@@ -1,0 +1,15 @@
+# v0.6.3 小需求与体验优化记录
+
+这个文件用于记录 v0.6.3 周期内较小的需求、体验优化和修复。后续同类变更继续追加到这里，避免为每个小项单独创建发布记录文件。
+
+## 2026-06-27
+
+### 修复 Antigravity 2.0 全局 Skill 同步路径
+
+- 修复将 Skill 同步到 Antigravity 时使用旧目录的问题（Issue [#79](https://github.com/qufei1993/skills-hub/issues/79)，PR [#80](https://github.com/qufei1993/skills-hub/pull/80)）。
+- 全局 Skill 同步目录从 `~/.gemini/antigravity/skills/` 更新为 `~/.gemini/config/skills/`，匹配 Antigravity 2.0 当前文档。
+- Antigravity 安装检测目录同步调整为 `~/.gemini/config/`。
+- 项目级 Skill 同步目录保持为 `<project>/.agents/skills/`。
+- 英文和中文工具支持列表已同步更新 Antigravity 路径。
+- 增加 Rust 回归测试，覆盖 Antigravity 全局 Skill 目录、检测目录和项目级目录映射。
+- 修复验证：`npm run check`。

--- a/src-tauri/src/core/tests/tool_adapters.rs
+++ b/src-tauri/src/core/tests/tool_adapters.rs
@@ -35,6 +35,17 @@ fn codewhale_adapter_uses_tool_specific_skill_dirs() {
 }
 
 #[test]
+fn antigravity_adapter_uses_current_global_skill_dir() {
+    let antigravity = adapter_by_key("antigravity").unwrap();
+
+    assert_eq!(antigravity.id, ToolId::Antigravity);
+    assert_eq!(antigravity.relative_skills_dir, ".gemini/config/skills");
+    assert_eq!(antigravity.relative_detect_dir, ".gemini/config");
+    assert_eq!(project_relative_skills_dir(&antigravity), ".agents/skills");
+    assert!(supports_project_scope(&antigravity));
+}
+
+#[test]
 fn adapters_sharing_skills_dir_groups_amp_and_kimi() {
     let amp = adapter_by_key("amp").unwrap();
     let group = adapters_sharing_skills_dir(&amp);

--- a/src-tauri/src/core/tool_adapters/mod.rs
+++ b/src-tauri/src/core/tool_adapters/mod.rs
@@ -154,9 +154,9 @@ pub fn default_tool_adapters() -> Vec<ToolAdapter> {
         ToolAdapter {
             id: ToolId::Antigravity,
             display_name: "Antigravity",
-            // add-skill global path: ~/.gemini/antigravity/skills/
-            relative_skills_dir: ".gemini/antigravity/skills",
-            relative_detect_dir: ".gemini/antigravity",
+            // Antigravity 2.0 global path: ~/.gemini/config/skills/
+            relative_skills_dir: ".gemini/config/skills",
+            relative_detect_dir: ".gemini/config",
         },
         ToolAdapter {
             id: ToolId::Amp,


### PR DESCRIPTION
## Summary
- update Antigravity global skill sync to ~/.gemini/config/skills for Antigravity 2.0
- update Antigravity detection/docs paths to ~/.gemini/config
- add a regression test for the Antigravity adapter path

Fixes #79

## Tests
- npm run check