### PR TITLE
feat: add scheduled skill auto update

### DIFF
--- a/docs/releases/v0.7.0/auto-update-optimizations.md
+++ b/docs/releases/v0.7.0/auto-update-optimizations.md
@@ -1,0 +1,76 @@
+# 自动更新体验优化
+
+## 功能概述
+
+v0.7.0 增加并优化 Skills 自动更新能力：支持通过用户级系统定时任务在应用关闭时更新 Skills，复用现有单个 Skill 更新逻辑；同时补充后台更新状态、进度详情、失败原因、网络代理配置和运行耗时信息，降低用户判断“是否真的在更新”“哪里失败了”“本次运行耗时多久”的成本。
+
+## 背景与目标
+
+- 之前 Skills 更新主要依赖用户在 UI 中手动点击单个 Skill 更新，应用关闭后不会继续执行。
+- 国内网络环境下访问 GitHub 可能不稳定，需要可控的本地代理配置，但不能默认让所有用户都依赖代理。
+- 后台任务执行时，用户需要能在重新打开应用后看到任务状态、更新进度、失败项和失败原因。
+- 进度详情只展示总数、成功、失败和等待数量，不方便判断上次任务从何时开始、何时完成以及耗时多久。
+
+## 主要变更
+
+### 系统定时更新
+
+- 新增用户级系统定时任务配置，默认周期为 24 小时，用户可在设置页开启/关闭并调整周期。
+- macOS 使用 LaunchAgent，Windows 使用当前用户计划任务，Linux 使用 user systemd timer。
+- 定时任务通过应用自身后台入口触发，复用现有 `update_managed_skill_from_source` 更新逻辑，不重新实现 Skill 更新流程。
+- 手动“立即更新”通过系统调度触发后台任务，用于验证真实后台路径。
+
+### 后台状态与进度详情
+
+- 设置页展示后台更新状态、上次运行状态、检查数量、更新数量和失败数量。
+- 新增“查看进度”弹窗，按“当前处理 / 失败 / 成功 / 等待中”分组展示。
+- 失败项展示 Skill 名称和失败原因，避免只暴露内部 ID 或完整堆栈。
+- 成功项默认仅展示汇总数量，避免大量成功列表占用空间。
+- 开始新一轮更新时清理上一次的进度和失败结果，避免用户误认为旧结果属于本次运行。
+
+### 开始时间、完成时间与耗时
+
+- 后端新增独立持久化字段：
+  - `skill_auto_update_last_started_at`
+  - `skill_auto_update_last_finished_at`
+- 进度详情弹窗展示开始时间、完成时间和耗时。
+- 运行中时完成时间显示“运行中”，耗时按当前时间动态计算。
+- 旧字段 `skill_auto_update_last_run_at` 继续保留，用于兼容现有“上次运行”和调度判断。
+
+### 网络代理配置
+
+- 新增“网络代理”设置，用于 GitHub API 和 Git 更新。
+- 首次未配置时自动检测本地 7890 端口；检测到后自动开启代理，否则默认关闭。
+- 用户可显式开启/关闭代理，并只需要配置端口；主机固定为 `127.0.0.1`，不在 UI 中暴露。
+- GitHub API、精选 Skills、GitHub Contents API 下载以及系统 `git clone/fetch` 均使用同一代理配置。
+- 已配置代理时，系统 `git` 失败不会回退到未显式代理的 libgit2，避免绕过代理直连 GitHub。
+
+## 涉及文件
+
+- `src-tauri/src/core/auto_update.rs`
+- `src-tauri/src/core/system_scheduler.rs`
+- `src-tauri/src/core/network_proxy.rs`
+- `src-tauri/src/core/git_fetcher.rs`
+- `src-tauri/src/core/github_search.rs`
+- `src-tauri/src/core/github_download.rs`
+- `src-tauri/src/core/featured_skills.rs`
+- `src-tauri/src/core/installer.rs`
+- `src-tauri/src/commands/mod.rs`
+- `src-tauri/src/lib.rs`
+- `src/components/skills/SettingsPage.tsx`
+- `src/components/skills/autoUpdateSettings.ts`
+- `src/components/skills/types.ts`
+- `src/App.tsx`
+- `src/App.css`
+- `src/i18n/resources.ts`
+
+## 验证
+
+实现完成后运行：
+
+```bash
+npm run check
+```
+
+覆盖 ESLint、前端测试、TypeScript/Vite 构建、Rust 格式、Clippy 和 Rust 测试。
+

--- a/docs/releases/v0.7.0/network-proxy.md
+++ b/docs/releases/v0.7.0/network-proxy.md
@@ -1,0 +1,82 @@
+# 网络代理配置
+
+## 功能概述
+
+v0.7.0 新增应用内“网络代理”配置，用于 GitHub API 和 Git 更新。该功能解决国内网络环境下 GitHub 访问不稳定的问题，同时避免让不需要代理的用户默认依赖本地代理。
+
+## 背景与目标
+
+- GitHub 搜索、精选 Skills、GitHub Contents API 下载和 Git clone/fetch 都依赖稳定的 GitHub 访问。
+- 之前应用主要依赖进程启动环境或系统 Git 配置，Dock/Finder 启动时不一定继承 shell 中的代理环境变量，行为不确定。
+- 直接默认强制 `127.0.0.1:7890` 会让没有代理软件的用户失败。
+- 需要一个显式、可理解、可关闭的应用内代理配置。
+
+## 主要变更
+
+### 设置页配置
+
+- 新增“网络代理”开关。
+- 只暴露代理端口，主机固定为 `127.0.0.1`，降低普通用户理解成本。
+- 首次未配置时自动检测本地 7890 端口：
+  - 检测到可连接：自动开启代理，端口为 7890。
+  - 检测不到：默认关闭代理。
+- 用户手动开启、关闭或修改端口后，以用户配置为准，不再自动覆盖。
+
+### 后端统一代理入口
+
+- 新增 `network_proxy` 核心模块，统一读取和保存代理配置。
+- HTTP 请求通过统一的 `github_http_client` 创建，显式配置代理。
+- 支持 HTTP 代理，也通过 `reqwest` socks feature 支持 `socks5` 代理能力。
+
+### Git 更新强制走配置代理
+
+- 系统 `git` 命令会显式注入：
+  - `http.proxy`
+  - `https.proxy`
+  - `http_proxy`
+  - `https_proxy`
+  - `all_proxy`
+- 配置了代理时，如果系统 `git` 执行失败，不回退到未显式代理的 libgit2，避免绕过代理直连 GitHub。
+
+## 影响范围
+
+代理配置会影响以下 GitHub 相关访问：
+
+- GitHub 搜索
+- 精选 Skills 拉取
+- GitHub Contents API 目录下载
+- Git Skill 安装、更新和缓存刷新
+- 自动更新中的 Git Skill 更新
+
+## 涉及文件
+
+- `src-tauri/src/core/network_proxy.rs`
+- `src-tauri/src/core/git_fetcher.rs`
+- `src-tauri/src/core/github_search.rs`
+- `src-tauri/src/core/github_download.rs`
+- `src-tauri/src/core/featured_skills.rs`
+- `src-tauri/src/core/installer.rs`
+- `src-tauri/src/commands/mod.rs`
+- `src-tauri/src/lib.rs`
+- `src/components/skills/SettingsPage.tsx`
+- `src/components/skills/types.ts`
+- `src/App.tsx`
+- `src/App.css`
+- `src/i18n/resources.ts`
+- `src-tauri/Cargo.toml`
+
+## 验证
+
+实现完成后运行：
+
+```bash
+npm run check
+```
+
+重点覆盖：
+
+- 未检测到 7890 时默认关闭代理。
+- 用户可显式开启/关闭代理。
+- 端口配置会生成 `http://127.0.0.1:<port>`。
+- Git 命令会注入代理参数和代理环境变量。
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ walkdir = "2.5"
 sha2 = "0.10"
 hex = "0.4"
 git2 = { version = "0.19", features = ["vendored-openssl"] }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "socks"] }
 junction = "1.1"
 uuid = { version = "1", features = ["v4"] }
 urlencoding = "2.1"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,12 @@ use tauri::State;
 
 use std::sync::Arc;
 
+use crate::core::auto_update::{
+    get_auto_update_config as get_auto_update_config_core, record_auto_update_triggered,
+    run_auto_update_now as run_auto_update_now_core,
+    set_auto_update_config as set_auto_update_config_core, AutoUpdateConfig,
+    AutoUpdateProgressSnapshot, AutoUpdateRunResult,
+};
 use crate::core::cache_cleanup::{
     cleanup_git_cache_dirs, get_git_cache_cleanup_days as get_git_cache_cleanup_days_core,
     get_git_cache_ttl_secs as get_git_cache_ttl_secs_core,
@@ -20,6 +26,12 @@ use crate::core::installer::{
     install_local_skill_from_selection, list_git_skills, list_local_skills,
     update_managed_skill_from_source, GitSkillCandidate, InstallResult, LocalSkillCandidate,
 };
+use crate::core::network_proxy::{
+    get_github_proxy_config as get_github_proxy_config_core,
+    get_github_proxy_url as get_github_proxy_url_core,
+    set_github_proxy_config as set_github_proxy_config_core,
+    set_github_proxy_url as set_github_proxy_url_core, GithubProxyConfig,
+};
 use crate::core::onboarding::{build_onboarding_plan, OnboardingPlan};
 use crate::core::skill_store::{SkillStore, SkillTargetRecord};
 use crate::core::skills_search::{
@@ -27,6 +39,10 @@ use crate::core::skills_search::{
 };
 use crate::core::sync_engine::{
     copy_dir_recursive, sync_dir_for_tool_with_overwrite, sync_dir_hybrid, SyncMode,
+};
+use crate::core::system_scheduler::{
+    current_scheduler_config, get_auto_update_task_status, install_auto_update_task,
+    trigger_auto_update_task_now, uninstall_auto_update_task,
 };
 use crate::core::tool_adapters::{
     adapter_by_key, adapters_sharing_project_skills_dir, is_tool_installed,
@@ -245,6 +261,129 @@ pub async fn set_git_cache_ttl_secs(
         .await
         .map_err(|err| err.to_string())?
         .map_err(format_anyhow_error)
+}
+
+#[derive(Debug, Serialize)]
+pub struct AutoUpdateConfigDto {
+    pub enabled: bool,
+    pub interval_hours: i64,
+    pub local_skill_count: usize,
+    pub protected_local_skill_count: usize,
+    pub task_registered: bool,
+    pub task_status_detail: String,
+    pub last_run_at: Option<i64>,
+    pub last_started_at: Option<i64>,
+    pub last_finished_at: Option<i64>,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+    pub last_checked: usize,
+    pub last_updated: usize,
+    pub last_failed: usize,
+    pub progress: AutoUpdateProgressSnapshot,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AutoUpdateRunResultDto {
+    pub checked: usize,
+    pub updated: usize,
+    pub failed: usize,
+    pub errors: Vec<String>,
+    pub progress: AutoUpdateProgressSnapshot,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GithubProxyConfigDto {
+    pub enabled: bool,
+    pub port: u16,
+    pub url: String,
+    pub auto_detected: bool,
+}
+
+#[tauri::command]
+pub async fn get_auto_update_config(
+    store: State<'_, SkillStore>,
+) -> Result<AutoUpdateConfigDto, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        get_auto_update_config_core(&store).map(to_auto_update_config_dto)
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn set_auto_update_config(
+    store: State<'_, SkillStore>,
+    enabled: bool,
+    intervalHours: i64,
+) -> Result<AutoUpdateConfigDto, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        if !(1..=24 * 30).contains(&intervalHours) {
+            anyhow::bail!("interval hours must be between 1 and 720");
+        }
+        if enabled {
+            let scheduler_config = current_scheduler_config(intervalHours)?;
+            install_auto_update_task(&scheduler_config)?;
+        } else {
+            uninstall_auto_update_task()?;
+        }
+
+        let existing = get_auto_update_config_core(&store)?;
+        let saved = set_auto_update_config_core(
+            &store,
+            AutoUpdateConfig {
+                enabled,
+                interval_hours: intervalHours,
+                local_skill_count: existing.local_skill_count,
+                protected_local_skill_count: existing.protected_local_skill_count,
+                last_run_at: existing.last_run_at,
+                last_started_at: existing.last_started_at,
+                last_finished_at: existing.last_finished_at,
+                last_status: existing.last_status,
+                last_error: existing.last_error,
+                last_checked: existing.last_checked,
+                last_updated: existing.last_updated,
+                last_failed: existing.last_failed,
+                progress: existing.progress,
+            },
+        )?;
+        Ok::<_, anyhow::Error>(to_auto_update_config_dto(saved))
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+pub async fn run_auto_update_now(
+    app: tauri::AppHandle,
+    store: State<'_, SkillStore>,
+) -> Result<AutoUpdateRunResultDto, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        run_auto_update_now_core(&app, &store).map(to_auto_update_run_result_dto)
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+pub async fn trigger_auto_update_task_now_cmd(store: State<'_, SkillStore>) -> Result<(), String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let config = get_auto_update_config_core(&store)?;
+        let scheduler_config = current_scheduler_config(config.interval_hours)?;
+        install_auto_update_task(&scheduler_config)?;
+        record_auto_update_triggered(&store)?;
+        trigger_auto_update_task_now()
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
 }
 
 #[derive(Debug, Serialize)]
@@ -797,12 +936,13 @@ pub async fn search_github(
     let limit = limit.unwrap_or(10) as usize;
     tauri::async_runtime::spawn_blocking(move || {
         let token = store.get_setting("github_token")?.unwrap_or_default();
+        let proxy_url = get_github_proxy_url_core(&store)?;
         let token_opt = if token.is_empty() {
             None
         } else {
             Some(token.as_str())
         };
-        search_github_repos(&query, limit, token_opt)
+        search_github_repos(&query, limit, token_opt, &proxy_url)
     })
     .await
     .map_err(|err| err.to_string())?
@@ -835,6 +975,57 @@ pub async fn set_github_token(store: State<'_, SkillStore>, token: String) -> Re
     .await
     .map_err(|err| err.to_string())?
     .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+pub async fn get_github_proxy_config(
+    store: State<'_, SkillStore>,
+) -> Result<GithubProxyConfigDto, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        get_github_proxy_config_core(&store).map(to_github_proxy_config_dto)
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn set_github_proxy_config(
+    store: State<'_, SkillStore>,
+    enabled: bool,
+    port: u16,
+) -> Result<GithubProxyConfigDto, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        set_github_proxy_config_core(&store, enabled, port).map(to_github_proxy_config_dto)
+    })
+    .await
+    .map_err(|err| err.to_string())?
+    .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+pub async fn get_github_proxy_url(store: State<'_, SkillStore>) -> Result<String, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || get_github_proxy_url_core(&store))
+        .await
+        .map_err(|err| err.to_string())?
+        .map_err(format_anyhow_error)
+}
+
+#[tauri::command]
+#[allow(non_snake_case)]
+pub async fn set_github_proxy_url(
+    store: State<'_, SkillStore>,
+    proxyUrl: String,
+) -> Result<String, String> {
+    let store = store.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || set_github_proxy_url_core(&store, &proxyUrl))
+        .await
+        .map_err(|err| err.to_string())?
+        .map_err(format_anyhow_error)
 }
 
 #[tauri::command]
@@ -1069,6 +1260,51 @@ fn to_install_dto(result: InstallResult) -> InstallResultDto {
         name: result.name,
         central_path: result.central_path.to_string_lossy().to_string(),
         content_hash: result.content_hash,
+    }
+}
+
+fn to_auto_update_config_dto(mut config: AutoUpdateConfig) -> AutoUpdateConfigDto {
+    let task_status = get_auto_update_task_status();
+    if config.last_status.as_deref() == Some("running")
+        && task_status.detail.contains("state = not running")
+    {
+        config.last_status = Some("stopped".to_string());
+    }
+    AutoUpdateConfigDto {
+        enabled: config.enabled,
+        interval_hours: config.interval_hours,
+        local_skill_count: config.local_skill_count,
+        protected_local_skill_count: config.protected_local_skill_count,
+        task_registered: task_status.registered,
+        task_status_detail: task_status.detail,
+        last_run_at: config.last_run_at,
+        last_started_at: config.last_started_at,
+        last_finished_at: config.last_finished_at,
+        last_status: config.last_status,
+        last_error: config.last_error,
+        last_checked: config.last_checked,
+        last_updated: config.last_updated,
+        last_failed: config.last_failed,
+        progress: config.progress,
+    }
+}
+
+fn to_auto_update_run_result_dto(result: AutoUpdateRunResult) -> AutoUpdateRunResultDto {
+    AutoUpdateRunResultDto {
+        checked: result.checked,
+        updated: result.updated,
+        failed: result.failed,
+        errors: result.errors,
+        progress: result.progress,
+    }
+}
+
+fn to_github_proxy_config_dto(config: GithubProxyConfig) -> GithubProxyConfigDto {
+    GithubProxyConfigDto {
+        enabled: config.enabled,
+        port: config.port,
+        url: config.url,
+        auto_detected: config.auto_detected,
     }
 }
 

--- a/src-tauri/src/core/auto_update.rs
+++ b/src-tauri/src/core/auto_update.rs
@@ -1,0 +1,422 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::installer::update_managed_skill_from_source;
+use super::skill_store::SkillStore;
+
+pub const AUTO_UPDATE_ENABLED_KEY: &str = "skill_auto_update_enabled";
+pub const AUTO_UPDATE_INTERVAL_HOURS_KEY: &str = "skill_auto_update_interval_hours";
+pub const AUTO_UPDATE_LAST_RUN_AT_KEY: &str = "skill_auto_update_last_run_at";
+pub const AUTO_UPDATE_LAST_STARTED_AT_KEY: &str = "skill_auto_update_last_started_at";
+pub const AUTO_UPDATE_LAST_FINISHED_AT_KEY: &str = "skill_auto_update_last_finished_at";
+pub const AUTO_UPDATE_LAST_STATUS_KEY: &str = "skill_auto_update_last_status";
+pub const AUTO_UPDATE_LAST_ERROR_KEY: &str = "skill_auto_update_last_error";
+pub const AUTO_UPDATE_LAST_CHECKED_KEY: &str = "skill_auto_update_last_checked";
+pub const AUTO_UPDATE_LAST_UPDATED_KEY: &str = "skill_auto_update_last_updated";
+pub const AUTO_UPDATE_LAST_FAILED_KEY: &str = "skill_auto_update_last_failed";
+pub const AUTO_UPDATE_PROGRESS_KEY: &str = "skill_auto_update_progress";
+
+pub const DEFAULT_AUTO_UPDATE_INTERVAL_HOURS: i64 = 24;
+const MIN_AUTO_UPDATE_INTERVAL_HOURS: i64 = 1;
+const MAX_AUTO_UPDATE_INTERVAL_HOURS: i64 = 24 * 30;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AutoUpdateConfig {
+    pub enabled: bool,
+    pub interval_hours: i64,
+    pub local_skill_count: usize,
+    pub protected_local_skill_count: usize,
+    pub last_run_at: Option<i64>,
+    pub last_started_at: Option<i64>,
+    pub last_finished_at: Option<i64>,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+    pub last_checked: usize,
+    pub last_updated: usize,
+    pub last_failed: usize,
+    pub progress: AutoUpdateProgressSnapshot,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoUpdateRunResult {
+    pub checked: usize,
+    pub updated: usize,
+    pub failed: usize,
+    pub errors: Vec<String>,
+    pub progress: AutoUpdateProgressSnapshot,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutoUpdateProgressSnapshot {
+    pub total: usize,
+    pub succeeded: Vec<AutoUpdateSkillProgress>,
+    pub failed: Vec<AutoUpdateSkillProgress>,
+    pub running: Option<AutoUpdateSkillProgress>,
+    pub pending: Vec<AutoUpdateSkillProgress>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutoUpdateSkillProgress {
+    pub skill_id: String,
+    pub name: String,
+    pub reason: Option<String>,
+}
+
+pub fn get_auto_update_config(store: &SkillStore) -> Result<AutoUpdateConfig> {
+    let enabled = store
+        .get_setting(AUTO_UPDATE_ENABLED_KEY)?
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    let interval_hours = store
+        .get_setting(AUTO_UPDATE_INTERVAL_HOURS_KEY)?
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|v| (MIN_AUTO_UPDATE_INTERVAL_HOURS..=MAX_AUTO_UPDATE_INTERVAL_HOURS).contains(v))
+        .unwrap_or(DEFAULT_AUTO_UPDATE_INTERVAL_HOURS);
+    let last_run_at = store
+        .get_setting(AUTO_UPDATE_LAST_RUN_AT_KEY)?
+        .and_then(|v| v.parse::<i64>().ok());
+    let last_started_at = store
+        .get_setting(AUTO_UPDATE_LAST_STARTED_AT_KEY)?
+        .and_then(|v| v.parse::<i64>().ok())
+        .or(last_run_at);
+    let last_status = store.get_setting(AUTO_UPDATE_LAST_STATUS_KEY)?;
+    let mut last_finished_at = store
+        .get_setting(AUTO_UPDATE_LAST_FINISHED_AT_KEY)?
+        .and_then(|v| v.parse::<i64>().ok());
+    if last_finished_at.is_none() && last_status.as_deref() != Some("running") {
+        last_finished_at = last_run_at;
+    }
+    let last_error = store.get_setting(AUTO_UPDATE_LAST_ERROR_KEY)?;
+    let last_checked = parse_usize_setting(store, AUTO_UPDATE_LAST_CHECKED_KEY)?;
+    let last_updated = parse_usize_setting(store, AUTO_UPDATE_LAST_UPDATED_KEY)?;
+    let last_failed = parse_usize_setting(store, AUTO_UPDATE_LAST_FAILED_KEY)?;
+    let mut progress = parse_progress_setting(store)?;
+    if progress_is_empty(&progress) {
+        progress = legacy_error_progress(store, last_checked, last_error.as_deref())?;
+    }
+    let (local_skill_count, protected_local_skill_count) = count_local_auto_update_skills(store)?;
+
+    Ok(AutoUpdateConfig {
+        enabled,
+        interval_hours,
+        local_skill_count,
+        protected_local_skill_count,
+        last_run_at,
+        last_started_at,
+        last_finished_at,
+        last_status,
+        last_error,
+        last_checked,
+        last_updated,
+        last_failed,
+        progress,
+    })
+}
+
+pub fn set_auto_update_config(
+    store: &SkillStore,
+    config: AutoUpdateConfig,
+) -> Result<AutoUpdateConfig> {
+    validate_interval(config.interval_hours)?;
+    store.set_setting(
+        AUTO_UPDATE_ENABLED_KEY,
+        if config.enabled { "true" } else { "false" },
+    )?;
+    store.set_setting(
+        AUTO_UPDATE_INTERVAL_HOURS_KEY,
+        &config.interval_hours.to_string(),
+    )?;
+    get_auto_update_config(store)
+}
+
+pub fn is_auto_update_due(config: &AutoUpdateConfig, now_ms: i64) -> bool {
+    if !config.enabled {
+        return false;
+    }
+    let Some(last_run_at) = config.last_run_at else {
+        return true;
+    };
+    let interval_ms = config
+        .interval_hours
+        .saturating_mul(60)
+        .saturating_mul(60)
+        .saturating_mul(1000);
+    now_ms.saturating_sub(last_run_at) >= interval_ms
+}
+
+#[allow(dead_code)]
+pub fn list_auto_update_skill_ids(store: &SkillStore) -> Result<Vec<String>> {
+    Ok(list_auto_update_skill_entries(store)?
+        .into_iter()
+        .map(|skill| skill.skill_id)
+        .collect())
+}
+
+pub fn run_auto_update_now<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    store: &SkillStore,
+) -> Result<AutoUpdateRunResult> {
+    let entries = list_auto_update_skill_entries(store)?;
+    let mut progress = AutoUpdateProgressSnapshot {
+        total: entries.len(),
+        pending: entries.clone(),
+        ..AutoUpdateProgressSnapshot::default()
+    };
+    record_auto_update_started(store, entries.len())?;
+    record_auto_update_progress_snapshot(store, &progress)?;
+    let mut result = AutoUpdateRunResult {
+        checked: entries.len(),
+        updated: 0,
+        failed: 0,
+        errors: Vec::new(),
+        progress: progress.clone(),
+    };
+
+    for entry in entries {
+        let skill_id = entry.skill_id.clone();
+        progress.running = Some(entry.clone());
+        progress
+            .pending
+            .retain(|pending| pending.skill_id != skill_id);
+        record_auto_update_progress_snapshot(store, &progress)?;
+
+        match update_managed_skill_from_source(app, store, &skill_id) {
+            Ok(update) => {
+                result.updated += 1;
+                progress.succeeded.push(AutoUpdateSkillProgress {
+                    skill_id,
+                    name: update.name,
+                    reason: None,
+                });
+            }
+            Err(err) => {
+                result.failed += 1;
+                let reason = format!("{:#}", err);
+                result.errors.push(format!("{}: {}", skill_id, reason));
+                progress.failed.push(AutoUpdateSkillProgress {
+                    skill_id,
+                    name: entry.name,
+                    reason: Some(reason),
+                });
+            }
+        }
+        progress.running = None;
+        result.progress = progress.clone();
+        record_auto_update_progress(store, &result)?;
+    }
+
+    record_auto_update_result(store, &result)?;
+    Ok(result)
+}
+
+pub fn record_auto_update_triggered(store: &SkillStore) -> Result<()> {
+    let entries = list_auto_update_skill_entries(store)?;
+    record_auto_update_started(store, entries.len())?;
+    record_auto_update_progress_snapshot(
+        store,
+        &AutoUpdateProgressSnapshot {
+            total: entries.len(),
+            pending: entries,
+            ..AutoUpdateProgressSnapshot::default()
+        },
+    )
+}
+
+fn record_auto_update_started(store: &SkillStore, checked: usize) -> Result<()> {
+    let started_at = now_ms();
+    store.set_setting(AUTO_UPDATE_LAST_RUN_AT_KEY, &started_at.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_STARTED_AT_KEY, &started_at.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_FINISHED_AT_KEY, "")?;
+    store.set_setting(AUTO_UPDATE_LAST_STATUS_KEY, "running")?;
+    store.set_setting(AUTO_UPDATE_LAST_CHECKED_KEY, &checked.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_UPDATED_KEY, "0")?;
+    store.set_setting(AUTO_UPDATE_LAST_FAILED_KEY, "0")?;
+    store.set_setting(AUTO_UPDATE_LAST_ERROR_KEY, "")?;
+    record_auto_update_progress_snapshot(
+        store,
+        &AutoUpdateProgressSnapshot {
+            total: checked,
+            ..AutoUpdateProgressSnapshot::default()
+        },
+    )?;
+    Ok(())
+}
+
+fn record_auto_update_progress(store: &SkillStore, result: &AutoUpdateRunResult) -> Result<()> {
+    store.set_setting(AUTO_UPDATE_LAST_STATUS_KEY, "running")?;
+    store.set_setting(AUTO_UPDATE_LAST_CHECKED_KEY, &result.checked.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_UPDATED_KEY, &result.updated.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_FAILED_KEY, &result.failed.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_ERROR_KEY, &result.errors.join("\n"))?;
+    record_auto_update_progress_snapshot(store, &result.progress)?;
+    Ok(())
+}
+
+fn record_auto_update_progress_snapshot(
+    store: &SkillStore,
+    progress: &AutoUpdateProgressSnapshot,
+) -> Result<()> {
+    store.set_setting(
+        AUTO_UPDATE_PROGRESS_KEY,
+        &serde_json::to_string(progress).unwrap_or_else(|_| "{}".to_string()),
+    )?;
+    Ok(())
+}
+
+pub fn run_due_auto_update<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    store: &SkillStore,
+) -> Result<Option<AutoUpdateRunResult>> {
+    let config = get_auto_update_config(store)?;
+    if !is_auto_update_due(&config, now_ms()) {
+        return Ok(None);
+    }
+    run_auto_update_now(app, store).map(Some)
+}
+
+fn record_auto_update_result(store: &SkillStore, result: &AutoUpdateRunResult) -> Result<()> {
+    let status = if result.failed == 0 { "ok" } else { "error" };
+    let finished_at = now_ms();
+    store.set_setting(AUTO_UPDATE_LAST_RUN_AT_KEY, &finished_at.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_FINISHED_AT_KEY, &finished_at.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_STATUS_KEY, status)?;
+    store.set_setting(AUTO_UPDATE_LAST_CHECKED_KEY, &result.checked.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_UPDATED_KEY, &result.updated.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_FAILED_KEY, &result.failed.to_string())?;
+    store.set_setting(AUTO_UPDATE_LAST_ERROR_KEY, &result.errors.join("\n"))?;
+    record_auto_update_progress_snapshot(store, &result.progress)?;
+    Ok(())
+}
+
+fn list_auto_update_skill_entries(store: &SkillStore) -> Result<Vec<AutoUpdateSkillProgress>> {
+    let mut skills = store
+        .list_skills()?
+        .into_iter()
+        .filter(|skill| skill.source_type == "git" || skill.source_type == "local")
+        .map(|skill| AutoUpdateSkillProgress {
+            skill_id: skill.id,
+            name: skill.name,
+            reason: None,
+        })
+        .collect::<Vec<_>>();
+    skills.sort_by(|a, b| a.skill_id.cmp(&b.skill_id));
+    Ok(skills)
+}
+
+fn count_local_auto_update_skills(store: &SkillStore) -> Result<(usize, usize)> {
+    let mut local_count = 0;
+    let mut protected_count = 0;
+    for skill in store.list_skills()? {
+        if skill.source_type != "local" {
+            continue;
+        }
+        local_count += 1;
+        if skill
+            .source_ref
+            .as_deref()
+            .map(is_macos_protected_user_path)
+            .unwrap_or(false)
+        {
+            protected_count += 1;
+        }
+    }
+    Ok((local_count, protected_count))
+}
+
+fn is_macos_protected_user_path(path: &str) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    let path = std::path::Path::new(path);
+    ["Desktop", "Documents", "Downloads"]
+        .iter()
+        .map(|dir| home.join(dir))
+        .any(|protected_dir| path.starts_with(protected_dir))
+}
+
+fn parse_usize_setting(store: &SkillStore, key: &str) -> Result<usize> {
+    Ok(store
+        .get_setting(key)?
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0))
+}
+
+fn parse_progress_setting(store: &SkillStore) -> Result<AutoUpdateProgressSnapshot> {
+    Ok(store
+        .get_setting(AUTO_UPDATE_PROGRESS_KEY)?
+        .and_then(|value| serde_json::from_str::<AutoUpdateProgressSnapshot>(&value).ok())
+        .unwrap_or_default())
+}
+
+fn progress_is_empty(progress: &AutoUpdateProgressSnapshot) -> bool {
+    progress.total == 0
+        && progress.succeeded.is_empty()
+        && progress.failed.is_empty()
+        && progress.running.is_none()
+        && progress.pending.is_empty()
+}
+
+fn legacy_error_progress(
+    store: &SkillStore,
+    total: usize,
+    raw_error: Option<&str>,
+) -> Result<AutoUpdateProgressSnapshot> {
+    let Some(raw_error) = raw_error else {
+        return Ok(AutoUpdateProgressSnapshot::default());
+    };
+
+    let mut failed = Vec::new();
+    for line in raw_error
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let Some((skill_id, reason)) = line.split_once(':') else {
+            failed.push(AutoUpdateSkillProgress {
+                skill_id: line.to_string(),
+                name: line.to_string(),
+                reason: Some(line.to_string()),
+            });
+            continue;
+        };
+        let skill_id = skill_id.trim();
+        let name = store
+            .get_skill_by_id(skill_id)?
+            .map(|skill| skill.name)
+            .unwrap_or_else(|| skill_id.to_string());
+        failed.push(AutoUpdateSkillProgress {
+            skill_id: skill_id.to_string(),
+            name,
+            reason: Some(reason.trim().to_string()),
+        });
+    }
+
+    Ok(AutoUpdateProgressSnapshot {
+        total,
+        failed,
+        ..AutoUpdateProgressSnapshot::default()
+    })
+}
+
+fn validate_interval(interval_hours: i64) -> Result<()> {
+    if !(MIN_AUTO_UPDATE_INTERVAL_HOURS..=MAX_AUTO_UPDATE_INTERVAL_HOURS).contains(&interval_hours)
+    {
+        anyhow::bail!(
+            "interval hours must be between {} and {}",
+            MIN_AUTO_UPDATE_INTERVAL_HOURS,
+            MAX_AUTO_UPDATE_INTERVAL_HOURS
+        );
+    }
+    Ok(())
+}
+
+fn now_ms() -> i64 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    now.as_millis() as i64
+}
+
+#[cfg(test)]
+#[path = "tests/auto_update.rs"]
+mod tests;

--- a/src-tauri/src/core/featured_skills.rs
+++ b/src-tauri/src/core/featured_skills.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
-use reqwest::blocking::Client;
 use serde::Deserialize;
 
+use super::network_proxy::{get_github_proxy_url, github_http_client};
 use super::skill_store::SkillStore;
 
 const FEATURED_SKILLS_URL: &str =
@@ -46,7 +46,8 @@ pub fn fetch_featured_skills(store: &SkillStore) -> Result<Vec<FeaturedSkill>> {
 }
 
 fn fetch_featured_skills_inner(url: &str, store: &SkillStore) -> Result<Vec<FeaturedSkill>> {
-    if let Ok(json_str) = fetch_from_url(url) {
+    let proxy_url = get_github_proxy_url(store)?;
+    if let Ok(json_str) = fetch_from_url(url, &proxy_url) {
         if let Ok(skills) = parse_and_filter(&json_str) {
             if !skills.is_empty() {
                 let _ = store.set_setting(CACHE_KEY, &json_str);
@@ -66,11 +67,8 @@ fn fetch_featured_skills_inner(url: &str, store: &SkillStore) -> Result<Vec<Feat
     Ok(parse_and_filter(BUNDLED_JSON).unwrap_or_default())
 }
 
-fn fetch_from_url(url: &str) -> Result<String> {
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(15))
-        .build()
-        .context("build HTTP client")?;
+fn fetch_from_url(url: &str, proxy_url: &str) -> Result<String> {
+    let client = github_http_client(proxy_url, Some(15))?;
 
     let body = client
         .get(url)

--- a/src-tauri/src/core/git_fetcher.rs
+++ b/src-tauri/src/core/git_fetcher.rs
@@ -14,12 +14,13 @@ pub fn clone_or_pull(
     dest: &Path,
     branch: Option<&str>,
     cancel: Option<&CancelToken>,
+    proxy_url: Option<&str>,
 ) -> Result<String> {
     // Prefer the system `git` binary if available. It tends to work better on macOS
     // networks because it respects user git config (proxy/certs) and OS trust store.
     if let Some(git_bin) = resolve_git_bin() {
         let started = Instant::now();
-        match clone_or_pull_via_git_cli(repo_url, dest, branch, cancel) {
+        match clone_or_pull_via_git_cli(repo_url, dest, branch, cancel, proxy_url) {
             Ok(head) => {
                 log::info!(
                     "[git_fetcher] git-cli ok (bin={}) {}s url={}",
@@ -30,6 +31,12 @@ pub fn clone_or_pull(
                 return Ok(head);
             }
             Err(err) => {
+                if proxy_url.is_some_and(|v| !v.trim().is_empty()) {
+                    anyhow::bail!(
+                        "git 命令执行失败。已配置 GitHub 代理，为确保访问一定走代理，已停止并不回退到内置 git。\n{:#}",
+                        err
+                    );
+                }
                 let allow_fallback = std::env::var("SKILLS_HUB_ALLOW_LIBGIT2_FALLBACK")
                     .ok()
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -96,6 +103,7 @@ pub fn clone_or_pull_sparse(
     branch: Option<&str>,
     subpath: &str,
     cancel: Option<&CancelToken>,
+    proxy_url: Option<&str>,
 ) -> Result<String> {
     let clean_subpath = subpath.trim_matches('/');
     if clean_subpath.is_empty() {
@@ -124,7 +132,7 @@ pub fn clone_or_pull_sparse(
 
         let out = run_cmd_with_timeout(
             {
-                let mut cmd = git_cmd();
+                let mut cmd = git_cmd(proxy_url);
                 cmd.arg("-C").arg(dest).args([
                     "sparse-checkout",
                     "set",
@@ -146,7 +154,7 @@ pub fn clone_or_pull_sparse(
 
         let out = run_cmd_with_timeout(
             {
-                let mut cmd = git_cmd();
+                let mut cmd = git_cmd(proxy_url);
                 cmd.arg("-C").arg(dest).args(["fetch", "--prune", "origin"]);
                 cmd
             },
@@ -161,7 +169,7 @@ pub fn clone_or_pull_sparse(
         if let Some(branch) = branch {
             let out = run_cmd_with_timeout(
                 {
-                    let mut cmd = git_cmd();
+                    let mut cmd = git_cmd(proxy_url);
                     cmd.arg("-C").arg(dest).args([
                         "checkout",
                         "-B",
@@ -183,7 +191,7 @@ pub fn clone_or_pull_sparse(
         } else {
             let out = run_cmd_with_timeout(
                 {
-                    let mut cmd = git_cmd();
+                    let mut cmd = git_cmd(proxy_url);
                     cmd.arg("-C")
                         .arg(dest)
                         .args(["reset", "--hard", "FETCH_HEAD"]);
@@ -201,7 +209,7 @@ pub fn clone_or_pull_sparse(
             }
         }
     } else {
-        let mut cmd = git_cmd();
+        let mut cmd = git_cmd(proxy_url);
         cmd.arg("clone").args([
             "--depth",
             "1",
@@ -225,7 +233,7 @@ pub fn clone_or_pull_sparse(
 
         let out = run_cmd_with_timeout(
             {
-                let mut cmd = git_cmd();
+                let mut cmd = git_cmd(proxy_url);
                 cmd.arg("-C").arg(dest).args([
                     "sparse-checkout",
                     "set",
@@ -248,7 +256,7 @@ pub fn clone_or_pull_sparse(
 
     let out = run_cmd_with_timeout(
         {
-            let mut cmd = git_cmd();
+            let mut cmd = git_cmd(proxy_url);
             cmd.arg("-C").arg(dest).args(["rev-parse", "HEAD"]);
             cmd
         },
@@ -332,9 +340,21 @@ fn git_bin_works(bin: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn git_cmd() -> Command {
+fn git_cmd(proxy_url: Option<&str>) -> Command {
     let bin = resolve_git_bin().unwrap_or_else(|| "git".to_string());
     let mut cmd = Command::new(bin);
+    if let Some(proxy_url) = proxy_url.map(str::trim).filter(|v| !v.is_empty()) {
+        cmd.arg("-c")
+            .arg(format!("http.proxy={}", proxy_url))
+            .arg("-c")
+            .arg(format!("https.proxy={}", proxy_url))
+            .env("http_proxy", proxy_url)
+            .env("https_proxy", proxy_url)
+            .env("all_proxy", proxy_url)
+            .env("HTTP_PROXY", proxy_url)
+            .env("HTTPS_PROXY", proxy_url)
+            .env("ALL_PROXY", proxy_url);
+    }
     // Never block on interactive auth prompts inside a GUI app.
     cmd.env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "echo");
@@ -389,6 +409,7 @@ fn clone_or_pull_via_git_cli(
     dest: &Path,
     branch: Option<&str>,
     cancel: Option<&CancelToken>,
+    proxy_url: Option<&str>,
 ) -> Result<String> {
     // Ensure parent exists so `git clone` can create dest.
     if let Some(parent) = dest.parent() {
@@ -410,7 +431,7 @@ fn clone_or_pull_via_git_cli(
         // Fetch updates.
         let out = run_cmd_with_timeout(
             {
-                let mut cmd = git_cmd();
+                let mut cmd = git_cmd(proxy_url);
                 cmd.arg("-C").arg(dest).args(["fetch", "--prune", "origin"]);
                 cmd
             },
@@ -426,7 +447,7 @@ fn clone_or_pull_via_git_cli(
         if let Some(branch) = branch {
             let out = run_cmd_with_timeout(
                 {
-                    let mut cmd = git_cmd();
+                    let mut cmd = git_cmd(proxy_url);
                     cmd.arg("-C").arg(dest).args([
                         "checkout",
                         "-B",
@@ -448,7 +469,7 @@ fn clone_or_pull_via_git_cli(
         } else {
             let out = run_cmd_with_timeout(
                 {
-                    let mut cmd = git_cmd();
+                    let mut cmd = git_cmd(proxy_url);
                     cmd.arg("-C")
                         .arg(dest)
                         .args(["reset", "--hard", "FETCH_HEAD"]);
@@ -467,7 +488,7 @@ fn clone_or_pull_via_git_cli(
         }
     } else {
         // Clone.
-        let mut cmd = git_cmd();
+        let mut cmd = git_cmd(proxy_url);
         cmd.arg("clone")
             .args(["--depth", "1", "--filter=blob:none", "--no-tags"]);
         if let Some(branch) = branch {
@@ -489,7 +510,7 @@ fn clone_or_pull_via_git_cli(
     if let Some(branch) = branch {
         let out = run_cmd_with_timeout(
             {
-                let mut cmd = git_cmd();
+                let mut cmd = git_cmd(proxy_url);
                 cmd.arg("-C").arg(dest).args(["checkout", branch]);
                 cmd
             },
@@ -510,7 +531,7 @@ fn clone_or_pull_via_git_cli(
     // Read HEAD revision.
     let out = run_cmd_with_timeout(
         {
-            let mut cmd = git_cmd();
+            let mut cmd = git_cmd(proxy_url);
             cmd.arg("-C").arg(dest).args(["rev-parse", "HEAD"]);
             cmd
         },

--- a/src-tauri/src/core/github_download.rs
+++ b/src-tauri/src/core/github_download.rs
@@ -8,6 +8,7 @@ use reqwest::blocking::Client;
 use serde::Deserialize;
 
 use super::cancel_token::CancelToken;
+use super::network_proxy::github_http_client;
 
 #[derive(Debug, Deserialize)]
 struct GithubContent {
@@ -18,30 +19,40 @@ struct GithubContent {
     path: String,
 }
 
+pub struct GithubDownloadOptions<'a> {
+    pub cancel: Option<&'a CancelToken>,
+    pub token: Option<&'a str>,
+    pub proxy_url: &'a str,
+}
+
 /// Download a directory from a GitHub repo using the Contents API.
 ///
 /// `owner`/`repo`: repository coordinates
 /// `branch`: branch or ref (e.g. "main")
 /// `path`: directory path within the repo (e.g. "skills/user/foo")
 /// `dest`: local directory to write files into (will be created)
-/// `cancel`: optional cancellation token
 pub fn download_github_directory(
     owner: &str,
     repo: &str,
     branch: &str,
     path: &str,
     dest: &Path,
-    cancel: Option<&CancelToken>,
-    token: Option<&str>,
+    options: GithubDownloadOptions<'_>,
 ) -> Result<()> {
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("build HTTP client")?;
+    let client = github_http_client(options.proxy_url, Some(30))?;
 
     std::fs::create_dir_all(dest).with_context(|| format!("create directory {:?}", dest))?;
 
-    download_dir_recursive(&client, owner, repo, branch, path, dest, cancel, token)
+    download_dir_recursive(
+        &client,
+        owner,
+        repo,
+        branch,
+        path,
+        dest,
+        options.cancel,
+        options.token,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/core/github_search.rs
+++ b/src-tauri/src/core/github_search.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
-use reqwest::blocking::Client;
 use serde::Deserialize;
+
+use super::network_proxy::github_http_client;
 
 #[derive(Debug, Deserialize)]
 struct SearchResponse {
@@ -31,17 +32,19 @@ pub fn search_github_repos(
     query: &str,
     limit: usize,
     token: Option<&str>,
+    proxy_url: &str,
 ) -> Result<Vec<RepoSummary>> {
-    search_github_repos_inner("https://api.github.com", query, limit, token)
+    search_github_repos_inner("https://api.github.com", query, limit, token, proxy_url)
 }
 
-fn search_github_repos_inner(
+pub(super) fn search_github_repos_inner(
     base_url: &str,
     query: &str,
     limit: usize,
     token: Option<&str>,
+    proxy_url: &str,
 ) -> Result<Vec<RepoSummary>> {
-    let client = Client::new();
+    let client = github_http_client(proxy_url, None)?;
     let base_url = base_url.trim_end_matches('/');
     let url = format!(
         "{}/search/repositories?q={}&per_page={}",

--- a/src-tauri/src/core/installer.rs
+++ b/src-tauri/src/core/installer.rs
@@ -11,7 +11,10 @@ use super::cancel_token::CancelToken;
 use super::central_repo::{ensure_central_repo, resolve_central_repo_path};
 use super::content_hash::hash_dir;
 use super::git_fetcher::{clone_or_pull, clone_or_pull_sparse};
-use super::github_download::{download_github_directory, parse_github_api_params};
+use super::github_download::{
+    download_github_directory, parse_github_api_params, GithubDownloadOptions,
+};
+use super::network_proxy::get_github_proxy_url;
 use super::skill_store::{SkillRecord, SkillStore};
 use super::sync_engine::copy_dir_recursive;
 use super::sync_engine::sync_dir_copy_with_overwrite;
@@ -126,6 +129,7 @@ pub fn install_git_skill<R: tauri::Runtime>(
     } else {
         Some(github_token.as_str())
     };
+    let github_proxy_url = get_github_proxy_url(store)?;
     let revision;
     if let Some((owner, repo, branch, subpath)) = parse_github_api_params(
         &parsed.clone_url,
@@ -173,8 +177,11 @@ pub fn install_git_skill<R: tauri::Runtime>(
                     &branch,
                     &subpath,
                     &central_path,
-                    cancel,
-                    github_token_opt,
+                    GithubDownloadOptions {
+                        cancel,
+                        token: github_token_opt,
+                        proxy_url: &github_proxy_url,
+                    },
                 ) {
                     Ok(()) => {
                         revision = format!("api-download-{}", branch);
@@ -1337,14 +1344,15 @@ fn clone_to_cache<R: tauri::Runtime>(
         repo_dir
     );
 
-    let rev = match clone_or_pull(clone_url, &repo_dir, branch, cancel) {
+    let proxy_url = get_github_proxy_url(store)?;
+    let rev = match clone_or_pull(clone_url, &repo_dir, branch, cancel, Some(&proxy_url)) {
         Ok(rev) => rev,
         Err(err) => {
             // If cache got corrupted, retry once from a clean state.
             if repo_dir.exists() {
                 let _ = std::fs::remove_dir_all(&repo_dir);
             }
-            clone_or_pull(clone_url, &repo_dir, branch, cancel)
+            clone_or_pull(clone_url, &repo_dir, branch, cancel, Some(&proxy_url))
                 .with_context(|| format!("{:#}", err))?
         }
     };
@@ -1421,14 +1429,29 @@ fn clone_to_cache_subpath<R: tauri::Runtime>(
         repo_dir
     );
 
-    let rev = match clone_or_pull_sparse(clone_url, &repo_dir, branch, subpath, cancel) {
+    let proxy_url = get_github_proxy_url(store)?;
+    let rev = match clone_or_pull_sparse(
+        clone_url,
+        &repo_dir,
+        branch,
+        subpath,
+        cancel,
+        Some(&proxy_url),
+    ) {
         Ok(rev) => rev,
         Err(err) => {
             if repo_dir.exists() {
                 let _ = std::fs::remove_dir_all(&repo_dir);
             }
-            clone_or_pull_sparse(clone_url, &repo_dir, branch, subpath, cancel)
-                .with_context(|| format!("{:#}", err))?
+            clone_or_pull_sparse(
+                clone_url,
+                &repo_dir,
+                branch,
+                subpath,
+                cancel,
+                Some(&proxy_url),
+            )
+            .with_context(|| format!("{:#}", err))?
         }
     };
 

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_update;
 pub mod cache_cleanup;
 pub mod cancel_token;
 pub mod central_repo;
@@ -7,10 +8,12 @@ pub mod git_fetcher;
 pub mod github_download;
 pub mod github_search;
 pub mod installer;
+pub mod network_proxy;
 pub mod onboarding;
 pub mod skill_files;
 pub mod skill_store;
 pub mod skills_search;
 pub mod sync_engine;
+pub mod system_scheduler;
 pub mod temp_cleanup;
 pub mod tool_adapters;

--- a/src-tauri/src/core/network_proxy.rs
+++ b/src-tauri/src/core/network_proxy.rs
@@ -1,0 +1,199 @@
+use anyhow::{Context, Result};
+use reqwest::blocking::{Client, ClientBuilder};
+use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
+
+use super::skill_store::SkillStore;
+
+pub const GITHUB_PROXY_URL_KEY: &str = "github_proxy_url";
+pub const DEFAULT_GITHUB_PROXY_URL: &str = "http://127.0.0.1:7890";
+const DEFAULT_GITHUB_PROXY_HOST: &str = "127.0.0.1";
+pub const DEFAULT_GITHUB_PROXY_PORT: u16 = 7890;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubProxyConfig {
+    pub enabled: bool,
+    pub port: u16,
+    pub url: String,
+    pub auto_detected: bool,
+}
+
+pub fn get_github_proxy_url(store: &SkillStore) -> Result<String> {
+    Ok(get_github_proxy_config(store)?.url)
+}
+
+pub fn get_github_proxy_config(store: &SkillStore) -> Result<GithubProxyConfig> {
+    Ok(match store.get_setting(GITHUB_PROXY_URL_KEY)? {
+        Some(value) => config_from_saved_url(&normalize_proxy_url(&value), false),
+        None => {
+            let url = auto_detect_github_proxy_url();
+            config_from_saved_url(&url, !url.is_empty())
+        }
+    })
+}
+
+pub fn set_github_proxy_url(store: &SkillStore, proxy_url: &str) -> Result<String> {
+    let normalized = normalize_proxy_url(proxy_url);
+    if !normalized.is_empty() {
+        validate_proxy_url(&normalized)?;
+    }
+    store.set_setting(GITHUB_PROXY_URL_KEY, &normalized)?;
+    Ok(normalized)
+}
+
+pub fn set_github_proxy_config(
+    store: &SkillStore,
+    enabled: bool,
+    port: u16,
+) -> Result<GithubProxyConfig> {
+    let normalized_port = if port == 0 {
+        DEFAULT_GITHUB_PROXY_PORT
+    } else {
+        port
+    };
+    let url = if enabled {
+        format!("http://{}:{}", DEFAULT_GITHUB_PROXY_HOST, normalized_port)
+    } else {
+        String::new()
+    };
+    if !url.is_empty() {
+        validate_proxy_url(&url)?;
+    }
+    store.set_setting(GITHUB_PROXY_URL_KEY, &url)?;
+    Ok(config_from_saved_url(&url, false))
+}
+
+pub fn auto_detect_github_proxy_url() -> String {
+    if local_tcp_port_is_open(
+        DEFAULT_GITHUB_PROXY_HOST,
+        DEFAULT_GITHUB_PROXY_PORT,
+        Duration::from_millis(200),
+    ) {
+        DEFAULT_GITHUB_PROXY_URL.to_string()
+    } else {
+        String::new()
+    }
+}
+
+pub fn github_http_client(proxy_url: &str, timeout_secs: Option<u64>) -> Result<Client> {
+    let mut builder = ClientBuilder::new();
+    if let Some(secs) = timeout_secs {
+        builder = builder.timeout(std::time::Duration::from_secs(secs));
+    }
+    let proxy_url = proxy_url.trim();
+    if !proxy_url.is_empty() {
+        builder = builder.proxy(
+            reqwest::Proxy::all(proxy_url)
+                .with_context(|| format!("invalid GitHub proxy URL: {}", proxy_url))?,
+        );
+    }
+    builder.build().context("build HTTP client")
+}
+
+pub fn normalize_proxy_url(proxy_url: &str) -> String {
+    proxy_url.trim().to_string()
+}
+
+fn config_from_saved_url(url: &str, auto_detected: bool) -> GithubProxyConfig {
+    let url = normalize_proxy_url(url);
+    let port = proxy_port_from_url(&url).unwrap_or(DEFAULT_GITHUB_PROXY_PORT);
+    GithubProxyConfig {
+        enabled: !url.is_empty(),
+        port,
+        url,
+        auto_detected,
+    }
+}
+
+fn proxy_port_from_url(url: &str) -> Option<u16> {
+    url.rsplit(':')
+        .next()
+        .and_then(|port| port.trim_end_matches('/').parse::<u16>().ok())
+}
+
+fn validate_proxy_url(proxy_url: &str) -> Result<()> {
+    reqwest::Proxy::all(proxy_url)
+        .map(|_| ())
+        .with_context(|| format!("invalid GitHub proxy URL: {}", proxy_url))
+}
+
+fn local_tcp_port_is_open(host: &str, port: u16, timeout: Duration) -> bool {
+    let Ok(addr) = format!("{}:{}", host, port).parse::<SocketAddr>() else {
+        return false;
+    };
+    TcpStream::connect_timeout(&addr, timeout).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::skill_store::SkillStore;
+    use std::net::TcpListener;
+
+    #[test]
+    fn empty_github_proxy_disables_proxy() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SkillStore::new(dir.path().join("db.sqlite"));
+        store.ensure_schema().unwrap();
+
+        let saved = set_github_proxy_url(&store, "  ").unwrap();
+
+        assert_eq!(saved, "");
+        assert_eq!(get_github_proxy_url(&store).unwrap(), "");
+    }
+
+    #[test]
+    fn proxy_config_disable_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SkillStore::new(dir.path().join("db.sqlite"));
+        store.ensure_schema().unwrap();
+
+        let saved = set_github_proxy_config(&store, false, 7890).unwrap();
+
+        assert!(!saved.enabled);
+        assert_eq!(saved.port, DEFAULT_GITHUB_PROXY_PORT);
+        assert_eq!(saved.url, "");
+        assert!(!get_github_proxy_config(&store).unwrap().enabled);
+    }
+
+    #[test]
+    fn proxy_config_uses_localhost_port() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SkillStore::new(dir.path().join("db.sqlite"));
+        store.ensure_schema().unwrap();
+
+        let saved = set_github_proxy_config(&store, true, 7897).unwrap();
+
+        assert!(saved.enabled);
+        assert_eq!(saved.port, 7897);
+        assert_eq!(saved.url, "http://127.0.0.1:7897");
+        assert_eq!(get_github_proxy_url(&store).unwrap(), saved.url);
+    }
+
+    #[test]
+    fn explicit_github_proxy_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SkillStore::new(dir.path().join("db.sqlite"));
+        store.ensure_schema().unwrap();
+
+        let saved = set_github_proxy_url(&store, " http://127.0.0.1:7890 ").unwrap();
+
+        assert_eq!(saved, DEFAULT_GITHUB_PROXY_URL);
+        assert_eq!(
+            get_github_proxy_url(&store).unwrap(),
+            DEFAULT_GITHUB_PROXY_URL
+        );
+    }
+
+    #[test]
+    fn local_tcp_port_detector_sees_open_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        assert!(local_tcp_port_is_open(
+            "127.0.0.1",
+            port,
+            Duration::from_millis(200)
+        ));
+    }
+}

--- a/src-tauri/src/core/system_scheduler.rs
+++ b/src-tauri/src/core/system_scheduler.rs
@@ -101,6 +101,7 @@ pub fn trigger_auto_update_task_now() -> Result<()> {
     }
 }
 
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
 pub fn build_launch_agent_plist(config: &SchedulerConfig) -> String {
     let exe = xml_escape(&config.executable.to_string_lossy());
     let interval_secs = config.interval_hours.saturating_mul(60).saturating_mul(60);
@@ -523,6 +524,7 @@ fn run_systemctl_user(args: &[&str]) -> Result<()> {
     Ok(())
 }
 
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
 fn xml_escape(input: &str) -> String {
     input
         .replace('&', "&amp;")

--- a/src-tauri/src/core/system_scheduler.rs
+++ b/src-tauri/src/core/system_scheduler.rs
@@ -1,0 +1,547 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+pub const TASK_LABEL: &str = "com.skillshub.autoupdate";
+const BACKGROUND_TASK_ARGS: [&str; 3] = ["--background-task", "update-skills", "--force"];
+
+#[derive(Clone, Debug)]
+pub struct SchedulerTaskStatus {
+    pub registered: bool,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct SchedulerConfig {
+    pub executable: PathBuf,
+    pub interval_hours: i64,
+}
+
+pub fn current_scheduler_config(interval_hours: i64) -> Result<SchedulerConfig> {
+    let current_exe = std::env::current_exe().context("resolve current executable")?;
+    Ok(SchedulerConfig {
+        executable: scheduler_executable_for_current_exe(&current_exe)?,
+        interval_hours,
+    })
+}
+
+pub fn scheduler_executable_for_current_exe(current_exe: &Path) -> Result<PathBuf> {
+    #[cfg(debug_assertions)]
+    {
+        let path = current_exe.to_string_lossy();
+        if path.contains("/target/debug/") {
+            let runner = current_exe.with_file_name("skills-hub-autoupdate-runner");
+            std::fs::copy(current_exe, &runner)
+                .with_context(|| format!("copy auto update runner to {:?}", runner))?;
+            return Ok(runner);
+        }
+    }
+
+    Ok(current_exe.to_path_buf())
+}
+
+pub fn install_auto_update_task(config: &SchedulerConfig) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        install_macos_launch_agent(config)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        install_windows_task(config)
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        install_linux_systemd_timer(config)
+    }
+}
+
+pub fn uninstall_auto_update_task() -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        uninstall_macos_launch_agent()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        uninstall_windows_task()
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        uninstall_linux_systemd_timer()
+    }
+}
+
+pub fn get_auto_update_task_status() -> SchedulerTaskStatus {
+    #[cfg(target_os = "macos")]
+    {
+        get_macos_launch_agent_status()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        get_windows_task_status()
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        get_linux_systemd_timer_status()
+    }
+}
+
+pub fn trigger_auto_update_task_now() -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        trigger_macos_launch_agent_now()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        trigger_windows_task_now()
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        trigger_linux_systemd_service_now()
+    }
+}
+
+pub fn build_launch_agent_plist(config: &SchedulerConfig) -> String {
+    let exe = xml_escape(&config.executable.to_string_lossy());
+    let interval_secs = config.interval_hours.saturating_mul(60).saturating_mul(60);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{TASK_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{exe}</string>
+    <string>{}</string>
+    <string>{}</string>
+    <string>{}</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>{interval_secs}</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>/tmp/skills-hub-auto-update.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/skills-hub-auto-update.err</string>
+</dict>
+</plist>
+"#,
+        BACKGROUND_TASK_ARGS[0], BACKGROUND_TASK_ARGS[1], BACKGROUND_TASK_ARGS[2],
+    )
+}
+
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
+pub fn summarize_launchctl_status(output: &str) -> String {
+    let mut parts = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("state =") || trimmed.starts_with("last exit code =") {
+            parts.push(trimmed.to_string());
+        }
+    }
+    if parts.is_empty() {
+        "launch agent loaded".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+#[cfg_attr(not(any(test, target_os = "macos")), allow(dead_code))]
+pub fn launchctl_kickstart_args(uid: u32) -> Vec<String> {
+    vec![
+        "kickstart".to_string(),
+        "-k".to_string(),
+        format!("gui/{uid}/{TASK_LABEL}"),
+    ]
+}
+
+#[cfg_attr(not(any(test, target_os = "windows")), allow(dead_code))]
+pub fn windows_schtasks_args(config: &SchedulerConfig) -> Vec<String> {
+    vec![
+        "/Create".to_string(),
+        "/F".to_string(),
+        "/TN".to_string(),
+        TASK_LABEL.to_string(),
+        "/SC".to_string(),
+        "HOURLY".to_string(),
+        "/MO".to_string(),
+        config.interval_hours.to_string(),
+        "/TR".to_string(),
+        format!(
+            "\"{}\" {} {} {}",
+            config.executable.to_string_lossy(),
+            BACKGROUND_TASK_ARGS[0],
+            BACKGROUND_TASK_ARGS[1],
+            BACKGROUND_TASK_ARGS[2]
+        ),
+    ]
+}
+
+#[cfg_attr(not(any(test, target_os = "windows")), allow(dead_code))]
+pub fn windows_schtasks_run_args() -> Vec<String> {
+    vec![
+        "/Run".to_string(),
+        "/TN".to_string(),
+        TASK_LABEL.to_string(),
+    ]
+}
+
+#[cfg_attr(not(any(test, all(unix, not(target_os = "macos")))), allow(dead_code))]
+pub fn build_systemd_service(config: &SchedulerConfig) -> String {
+    format!(
+        "[Unit]\nDescription=Skills Hub automatic skill update\n\n[Service]\nType=oneshot\nExecStart={} {} {} {}\n",
+        systemd_escape_path(&config.executable),
+        BACKGROUND_TASK_ARGS[0],
+        BACKGROUND_TASK_ARGS[1],
+        BACKGROUND_TASK_ARGS[2]
+    )
+}
+
+#[cfg_attr(not(any(test, all(unix, not(target_os = "macos")))), allow(dead_code))]
+pub fn build_systemd_timer(config: &SchedulerConfig) -> String {
+    format!(
+        "[Unit]\nDescription=Run Skills Hub automatic skill update\n\n[Timer]\nOnBootSec=5min\nOnUnitActiveSec={}h\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n",
+        config.interval_hours
+    )
+}
+
+#[cfg_attr(not(any(test, all(unix, not(target_os = "macos")))), allow(dead_code))]
+pub fn systemd_start_args() -> Vec<String> {
+    vec![
+        "--user".to_string(),
+        "start".to_string(),
+        format!("{TASK_LABEL}.service"),
+    ]
+}
+
+#[cfg(target_os = "macos")]
+fn install_macos_launch_agent(config: &SchedulerConfig) -> Result<()> {
+    let dir = dirs::home_dir()
+        .context("resolve home dir")?
+        .join("Library/LaunchAgents");
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {:?}", dir))?;
+    let plist = dir.join(format!("{TASK_LABEL}.plist"));
+    let _ = Command::new("launchctl").arg("unload").arg(&plist).output();
+    std::fs::write(&plist, build_launch_agent_plist(config))
+        .with_context(|| format!("write {:?}", plist))?;
+    let out = Command::new("launchctl")
+        .arg("load")
+        .arg(&plist)
+        .output()
+        .context("launchctl load")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "launchctl load failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn uninstall_macos_launch_agent() -> Result<()> {
+    let plist = dirs::home_dir()
+        .context("resolve home dir")?
+        .join("Library/LaunchAgents")
+        .join(format!("{TASK_LABEL}.plist"));
+    let _ = Command::new("launchctl").arg("unload").arg(&plist).output();
+    if plist.exists() {
+        std::fs::remove_file(&plist).with_context(|| format!("remove {:?}", plist))?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn get_macos_launch_agent_status() -> SchedulerTaskStatus {
+    let plist = match dirs::home_dir() {
+        Some(home) => home
+            .join("Library/LaunchAgents")
+            .join(format!("{TASK_LABEL}.plist")),
+        None => {
+            return SchedulerTaskStatus {
+                registered: false,
+                detail: "home dir not found".to_string(),
+            };
+        }
+    };
+    if !plist.exists() {
+        return SchedulerTaskStatus {
+            registered: false,
+            detail: format!("missing {}", plist.to_string_lossy()),
+        };
+    }
+    let uid = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+    let Some(uid) = uid else {
+        return SchedulerTaskStatus {
+            registered: true,
+            detail: format!("plist exists: {}", plist.to_string_lossy()),
+        };
+    };
+    let out = Command::new("launchctl")
+        .args(["print", &format!("gui/{uid}/{TASK_LABEL}")])
+        .output();
+    match out {
+        Ok(out) if out.status.success() => SchedulerTaskStatus {
+            registered: true,
+            detail: summarize_launchctl_status(&String::from_utf8_lossy(&out.stdout)),
+        },
+        Ok(out) => SchedulerTaskStatus {
+            registered: false,
+            detail: format!(
+                "plist exists but launchctl cannot find loaded job: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        },
+        Err(err) => SchedulerTaskStatus {
+            registered: true,
+            detail: format!("plist exists; launchctl check failed: {err}"),
+        },
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn trigger_macos_launch_agent_now() -> Result<()> {
+    let status = get_macos_launch_agent_status();
+    if !status.registered {
+        anyhow::bail!("auto update task is not ready: {}", status.detail);
+    }
+    let uid = current_uid()?;
+    let out = Command::new("launchctl")
+        .args(launchctl_kickstart_args(uid))
+        .output()
+        .context("launchctl kickstart")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "launchctl kickstart failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn current_uid() -> Result<u32> {
+    let out = Command::new("id").arg("-u").output().context("id -u")?;
+    if !out.status.success() {
+        anyhow::bail!("id -u failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    let raw = String::from_utf8_lossy(&out.stdout);
+    raw.trim()
+        .parse::<u32>()
+        .with_context(|| format!("parse uid from {}", raw.trim()))
+}
+
+#[cfg(target_os = "windows")]
+fn install_windows_task(config: &SchedulerConfig) -> Result<()> {
+    let out = Command::new("schtasks")
+        .args(windows_schtasks_args(config))
+        .output()
+        .context("schtasks create")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "schtasks create failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn uninstall_windows_task() -> Result<()> {
+    let out = Command::new("schtasks")
+        .args(["/Delete", "/F", "/TN", TASK_LABEL])
+        .output()
+        .context("schtasks delete")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if !stderr.contains("cannot find") {
+            anyhow::bail!("schtasks delete failed: {}", stderr);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn get_windows_task_status() -> SchedulerTaskStatus {
+    let out = Command::new("schtasks")
+        .args(["/Query", "/TN", TASK_LABEL])
+        .output();
+    match out {
+        Ok(out) if out.status.success() => SchedulerTaskStatus {
+            registered: true,
+            detail: "scheduled task registered".to_string(),
+        },
+        Ok(out) => SchedulerTaskStatus {
+            registered: false,
+            detail: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        },
+        Err(err) => SchedulerTaskStatus {
+            registered: false,
+            detail: format!("schtasks query failed: {err}"),
+        },
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn trigger_windows_task_now() -> Result<()> {
+    let status = get_windows_task_status();
+    if !status.registered {
+        anyhow::bail!("auto update task is not ready: {}", status.detail);
+    }
+    let out = Command::new("schtasks")
+        .args(windows_schtasks_run_args())
+        .output()
+        .context("schtasks run")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "schtasks run failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn install_linux_systemd_timer(config: &SchedulerConfig) -> Result<()> {
+    let dir = dirs::home_dir()
+        .context("resolve home dir")?
+        .join(".config/systemd/user");
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {:?}", dir))?;
+    let service = dir.join(format!("{TASK_LABEL}.service"));
+    let timer = dir.join(format!("{TASK_LABEL}.timer"));
+    std::fs::write(&service, build_systemd_service(config))
+        .with_context(|| format!("write {:?}", service))?;
+    std::fs::write(&timer, build_systemd_timer(config))
+        .with_context(|| format!("write {:?}", timer))?;
+    run_systemctl_user(&["daemon-reload"])?;
+    run_systemctl_user(&["enable", "--now", &format!("{TASK_LABEL}.timer")])?;
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn uninstall_linux_systemd_timer() -> Result<()> {
+    let _ = run_systemctl_user(&["disable", "--now", &format!("{TASK_LABEL}.timer")]);
+    let dir = dirs::home_dir()
+        .context("resolve home dir")?
+        .join(".config/systemd/user");
+    for ext in ["service", "timer"] {
+        let path = dir.join(format!("{TASK_LABEL}.{ext}"));
+        if path.exists() {
+            std::fs::remove_file(&path).with_context(|| format!("remove {:?}", path))?;
+        }
+    }
+    let _ = run_systemctl_user(&["daemon-reload"]);
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn get_linux_systemd_timer_status() -> SchedulerTaskStatus {
+    let unit = format!("{TASK_LABEL}.timer");
+    let enabled = Command::new("systemctl")
+        .arg("--user")
+        .args(["is-enabled", &unit])
+        .output();
+    let active = Command::new("systemctl")
+        .arg("--user")
+        .args(["is-active", &unit])
+        .output();
+    let enabled_ok = enabled
+        .as_ref()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    let active_ok = active
+        .as_ref()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if enabled_ok && active_ok {
+        return SchedulerTaskStatus {
+            registered: true,
+            detail: "systemd timer enabled and active".to_string(),
+        };
+    }
+    let detail = match (enabled, active) {
+        (Ok(enabled), Ok(active)) => format!(
+            "enabled={}, active={}",
+            String::from_utf8_lossy(&enabled.stdout).trim(),
+            String::from_utf8_lossy(&active.stdout).trim()
+        ),
+        (Err(err), _) | (_, Err(err)) => format!("systemctl check failed: {err}"),
+    };
+    SchedulerTaskStatus {
+        registered: false,
+        detail,
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn trigger_linux_systemd_service_now() -> Result<()> {
+    let status = get_linux_systemd_timer_status();
+    if !status.registered {
+        anyhow::bail!("auto update task is not ready: {}", status.detail);
+    }
+    let args = systemd_start_args();
+    let out = Command::new("systemctl")
+        .args(args.iter().map(String::as_str))
+        .output()
+        .context("systemctl --user start auto update service")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "systemctl start failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn run_systemctl_user(args: &[&str]) -> Result<()> {
+    let out = Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .output()
+        .with_context(|| format!("systemctl --user {}", args.join(" ")))?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "systemctl --user {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn xml_escape(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg_attr(not(all(unix, not(target_os = "macos"))), allow(dead_code))]
+fn systemd_escape_path(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    if raw.contains(' ') {
+        format!("\"{}\"", raw.replace('"', "\\\""))
+    } else {
+        raw.to_string()
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/system_scheduler.rs"]
+mod tests;

--- a/src-tauri/src/core/tests/auto_update.rs
+++ b/src-tauri/src/core/tests/auto_update.rs
@@ -1,0 +1,382 @@
+use super::{
+    record_auto_update_progress, record_auto_update_progress_snapshot, record_auto_update_result,
+    record_auto_update_started, record_auto_update_triggered, AutoUpdateProgressSnapshot,
+    AutoUpdateRunResult, AutoUpdateSkillProgress,
+};
+use crate::core::auto_update::{
+    get_auto_update_config, is_auto_update_due, set_auto_update_config, AutoUpdateConfig,
+    AUTO_UPDATE_LAST_CHECKED_KEY, AUTO_UPDATE_LAST_ERROR_KEY, DEFAULT_AUTO_UPDATE_INTERVAL_HOURS,
+};
+use crate::core::skill_store::{SkillRecord, SkillStore};
+
+fn make_store() -> (tempfile::TempDir, SkillStore) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("test.db");
+    let store = SkillStore::new(db);
+    store.ensure_schema().expect("ensure_schema");
+    (dir, store)
+}
+
+fn make_skill(id: &str, source_type: &str, central_path: &str) -> SkillRecord {
+    SkillRecord {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: None,
+        source_type: source_type.to_string(),
+        source_ref: Some("/tmp/source".to_string()),
+        source_subpath: None,
+        source_revision: None,
+        central_path: central_path.to_string(),
+        content_hash: None,
+        created_at: 1,
+        updated_at: 1,
+        last_sync_at: None,
+        last_seen_at: 1,
+        status: "ok".to_string(),
+    }
+}
+
+#[test]
+fn default_config_is_disabled_with_24_hour_interval() {
+    let (_dir, store) = make_store();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert!(!config.enabled);
+    assert_eq!(config.interval_hours, DEFAULT_AUTO_UPDATE_INTERVAL_HOURS);
+    assert_eq!(config.last_run_at, None);
+    assert_eq!(config.last_status.as_deref(), None);
+}
+
+#[test]
+fn config_roundtrips_and_rejects_invalid_interval() {
+    let (_dir, store) = make_store();
+
+    let saved = set_auto_update_config(
+        &store,
+        AutoUpdateConfig {
+            enabled: true,
+            interval_hours: 12,
+            local_skill_count: 0,
+            protected_local_skill_count: 0,
+            last_run_at: None,
+            last_started_at: None,
+            last_finished_at: None,
+            last_status: None,
+            last_error: None,
+            last_checked: 0,
+            last_updated: 0,
+            last_failed: 0,
+            progress: AutoUpdateProgressSnapshot::default(),
+        },
+    )
+    .unwrap();
+
+    assert!(saved.enabled);
+    assert_eq!(saved.interval_hours, 12);
+    assert_eq!(get_auto_update_config(&store).unwrap().interval_hours, 12);
+
+    let err = set_auto_update_config(
+        &store,
+        AutoUpdateConfig {
+            enabled: true,
+            interval_hours: 0,
+            local_skill_count: 0,
+            protected_local_skill_count: 0,
+            last_run_at: None,
+            last_started_at: None,
+            last_finished_at: None,
+            last_status: None,
+            last_error: None,
+            last_checked: 0,
+            last_updated: 0,
+            last_failed: 0,
+            progress: AutoUpdateProgressSnapshot::default(),
+        },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("interval"));
+}
+
+#[test]
+fn due_check_respects_enabled_state_and_interval() {
+    let disabled = AutoUpdateConfig {
+        enabled: false,
+        interval_hours: 24,
+        local_skill_count: 0,
+        protected_local_skill_count: 0,
+        last_run_at: Some(1_000),
+        last_started_at: Some(1_000),
+        last_finished_at: Some(1_000),
+        last_status: None,
+        last_error: None,
+        last_checked: 0,
+        last_updated: 0,
+        last_failed: 0,
+        progress: AutoUpdateProgressSnapshot::default(),
+    };
+    assert!(!is_auto_update_due(&disabled, 1_000 + 48 * 60 * 60 * 1000));
+
+    let enabled_never_run = AutoUpdateConfig {
+        enabled: true,
+        ..disabled.clone()
+    };
+    let enabled_never_run = AutoUpdateConfig {
+        last_run_at: None,
+        ..enabled_never_run
+    };
+    assert!(is_auto_update_due(&enabled_never_run, 1_000));
+
+    let recent = AutoUpdateConfig {
+        enabled: true,
+        interval_hours: 24,
+        last_run_at: Some(1_000),
+        ..disabled
+    };
+    assert!(!is_auto_update_due(&recent, 1_000 + 23 * 60 * 60 * 1000));
+    assert!(is_auto_update_due(&recent, 1_000 + 24 * 60 * 60 * 1000));
+}
+
+#[test]
+fn eligible_skills_include_git_and_local_sources() {
+    let (_dir, store) = make_store();
+    store
+        .upsert_skill(&make_skill("git-skill", "git", "/tmp/git-skill"))
+        .unwrap();
+    store
+        .upsert_skill(&make_skill("local-skill", "local", "/tmp/local-skill"))
+        .unwrap();
+    store
+        .upsert_skill(&make_skill("other-skill", "generated", "/tmp/other-skill"))
+        .unwrap();
+
+    let ids = crate::core::auto_update::list_auto_update_skill_ids(&store).unwrap();
+
+    assert_eq!(
+        ids,
+        vec!["git-skill".to_string(), "local-skill".to_string()]
+    );
+}
+
+#[test]
+fn config_reports_local_skills_for_permission_hint() {
+    let (_dir, store) = make_store();
+    store
+        .upsert_skill(&make_skill("local-skill", "local", "/tmp/local-skill"))
+        .unwrap();
+    store
+        .upsert_skill(&make_skill("git-skill", "git", "/tmp/git-skill"))
+        .unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.local_skill_count, 1);
+}
+
+#[test]
+fn progress_snapshot_is_persisted_while_update_is_running() {
+    let (_dir, store) = make_store();
+
+    record_auto_update_progress(
+        &store,
+        &AutoUpdateRunResult {
+            checked: 60,
+            updated: 12,
+            failed: 3,
+            errors: vec!["skill-a: network timeout".to_string()],
+            progress: AutoUpdateProgressSnapshot::default(),
+        },
+    )
+    .unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.last_status.as_deref(), Some("running"));
+    assert_eq!(config.last_checked, 60);
+    assert_eq!(config.last_updated, 12);
+    assert_eq!(config.last_failed, 3);
+    assert_eq!(
+        config.last_error.as_deref(),
+        Some("skill-a: network timeout")
+    );
+}
+
+#[test]
+fn starting_update_clears_previous_result_and_progress() {
+    let (_dir, store) = make_store();
+    record_auto_update_progress(
+        &store,
+        &AutoUpdateRunResult {
+            checked: 2,
+            updated: 1,
+            failed: 1,
+            errors: vec!["old-skill: old error".to_string()],
+            progress: AutoUpdateProgressSnapshot {
+                total: 2,
+                succeeded: vec![AutoUpdateSkillProgress {
+                    skill_id: "done".to_string(),
+                    name: "Done".to_string(),
+                    reason: None,
+                }],
+                failed: vec![AutoUpdateSkillProgress {
+                    skill_id: "bad".to_string(),
+                    name: "Bad".to_string(),
+                    reason: Some("old error".to_string()),
+                }],
+                running: None,
+                pending: vec![],
+            },
+        },
+    )
+    .unwrap();
+
+    record_auto_update_started(&store, 3).unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.last_status.as_deref(), Some("running"));
+    assert!(config.last_started_at.is_some());
+    assert_eq!(config.last_finished_at, None);
+    assert_eq!(config.last_checked, 3);
+    assert_eq!(config.last_updated, 0);
+    assert_eq!(config.last_failed, 0);
+    assert_eq!(config.last_error.as_deref(), Some(""));
+    assert_eq!(config.progress.total, 3);
+    assert!(config.progress.succeeded.is_empty());
+    assert!(config.progress.failed.is_empty());
+    assert!(config.progress.running.is_none());
+    assert!(config.progress.pending.is_empty());
+}
+
+#[test]
+fn started_and_finished_times_are_recorded_separately() {
+    let (_dir, store) = make_store();
+
+    record_auto_update_started(&store, 1).unwrap();
+    let running = get_auto_update_config(&store).unwrap();
+    assert!(running.last_started_at.is_some());
+    assert_eq!(running.last_finished_at, None);
+
+    record_auto_update_result(
+        &store,
+        &AutoUpdateRunResult {
+            checked: 1,
+            updated: 1,
+            failed: 0,
+            errors: vec![],
+            progress: AutoUpdateProgressSnapshot::default(),
+        },
+    )
+    .unwrap();
+
+    let finished = get_auto_update_config(&store).unwrap();
+    assert!(finished.last_started_at.is_some());
+    assert!(finished.last_finished_at.is_some());
+    assert!(finished.last_finished_at >= finished.last_started_at);
+}
+
+#[test]
+fn triggered_update_clears_previous_result_using_current_eligible_count() {
+    let (_dir, store) = make_store();
+    store
+        .upsert_skill(&make_skill("git-skill", "git", "/tmp/git-skill"))
+        .unwrap();
+    store
+        .upsert_skill(&make_skill("local-skill", "local", "/tmp/local-skill"))
+        .unwrap();
+    store
+        .set_setting(AUTO_UPDATE_LAST_ERROR_KEY, "old: failed")
+        .unwrap();
+
+    record_auto_update_triggered(&store).unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.last_status.as_deref(), Some("running"));
+    assert_eq!(config.last_checked, 2);
+    assert_eq!(config.last_failed, 0);
+    assert_eq!(config.last_error.as_deref(), Some(""));
+    assert_eq!(config.progress.total, 2);
+    assert_eq!(config.progress.pending.len(), 2);
+    assert!(config.progress.failed.is_empty());
+}
+
+#[test]
+fn structured_progress_snapshot_tracks_success_failure_running_and_pending() {
+    let (_dir, store) = make_store();
+
+    record_auto_update_progress_snapshot(
+        &store,
+        &AutoUpdateProgressSnapshot {
+            total: 4,
+            succeeded: vec![AutoUpdateSkillProgress {
+                skill_id: "done".to_string(),
+                name: "Done Skill".to_string(),
+                reason: None,
+            }],
+            failed: vec![AutoUpdateSkillProgress {
+                skill_id: "bad".to_string(),
+                name: "Bad Skill".to_string(),
+                reason: Some("network timeout".to_string()),
+            }],
+            running: Some(AutoUpdateSkillProgress {
+                skill_id: "now".to_string(),
+                name: "Now Skill".to_string(),
+                reason: None,
+            }),
+            pending: vec![AutoUpdateSkillProgress {
+                skill_id: "next".to_string(),
+                name: "Next Skill".to_string(),
+                reason: None,
+            }],
+        },
+    )
+    .unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.progress.total, 4);
+    assert_eq!(config.progress.succeeded[0].name, "Done Skill");
+    assert_eq!(
+        config.progress.failed[0].reason.as_deref(),
+        Some("network timeout")
+    );
+    assert_eq!(
+        config
+            .progress
+            .running
+            .as_ref()
+            .map(|item| item.skill_id.as_str()),
+        Some("now")
+    );
+    assert_eq!(config.progress.pending[0].skill_id, "next");
+}
+
+#[test]
+fn legacy_error_progress_uses_skill_name_when_available() {
+    let (_dir, store) = make_store();
+    let mut skill = make_skill(
+        "64798624-ca2a-4811-8747-00147567facf",
+        "local",
+        "/tmp/youdaonote",
+    );
+    skill.name = "有道云笔记".to_string();
+    store.upsert_skill(&skill).unwrap();
+    store
+        .set_setting(AUTO_UPDATE_LAST_CHECKED_KEY, "1")
+        .unwrap();
+    store
+        .set_setting(
+            AUTO_UPDATE_LAST_ERROR_KEY,
+            "64798624-ca2a-4811-8747-00147567facf: source path not found: \"/Users/may/Downloads/youdaonote\"",
+        )
+        .unwrap();
+
+    let config = get_auto_update_config(&store).unwrap();
+
+    assert_eq!(config.progress.failed[0].name, "有道云笔记");
+    assert_eq!(
+        config.progress.failed[0].reason.as_deref(),
+        Some("source path not found: \"/Users/may/Downloads/youdaonote\"")
+    );
+}

--- a/src-tauri/src/core/tests/git_fetcher.rs
+++ b/src-tauri/src/core/tests/git_fetcher.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+use super::git_cmd;
 use crate::core::git_fetcher::{clone_or_pull, clone_or_pull_sparse};
 
 fn commit_file(repo: &git2::Repository, path: &str, content: &[u8], msg: &str) -> git2::Oid {
@@ -40,6 +41,7 @@ fn clone_then_pull_updates_head() {
         &dest,
         None,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(h1, c2.to_string(), "首次 clone 应指向最新提交");
@@ -48,6 +50,7 @@ fn clone_then_pull_updates_head() {
     let h2 = clone_or_pull(
         origin_dir.path().to_string_lossy().as_ref(),
         &dest,
+        None,
         None,
         None,
     )
@@ -71,6 +74,7 @@ fn sparse_clone_only_materializes_requested_subpath() {
         None,
         "skills/a",
         None,
+        None,
     ) {
         Ok(head) => head,
         Err(err) if format!("{:#}", err).contains("system git is required") => return,
@@ -82,5 +86,24 @@ fn sparse_clone_only_materializes_requested_subpath() {
     assert!(
         !dest.join("skills/b/SKILL.md").exists(),
         "未请求的子目录不应被检出到工作区"
+    );
+}
+
+#[test]
+fn git_command_injects_configured_proxy() {
+    let cmd = git_cmd(Some("http://127.0.0.1:7890"));
+    let args = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(args.contains(&"http.proxy=http://127.0.0.1:7890".to_string()));
+    assert!(args.contains(&"https.proxy=http://127.0.0.1:7890".to_string()));
+    assert_eq!(
+        cmd.get_envs()
+            .find(|(key, _)| key.to_string_lossy() == "https_proxy")
+            .and_then(|(_, value)| value)
+            .map(|value| value.to_string_lossy().to_string()),
+        Some("http://127.0.0.1:7890".to_string())
     );
 }

--- a/src-tauri/src/core/tests/github_search.rs
+++ b/src-tauri/src/core/tests/github_search.rs
@@ -33,7 +33,7 @@ fn limit_is_clamped() {
         .with_body(json_one_repo())
         .create();
 
-    let out = search_github_repos_inner(&server.url(), "hello", 0, None).unwrap();
+    let out = search_github_repos_inner(&server.url(), "hello", 0, None, "").unwrap();
     assert_eq!(out.len(), 1);
 
     let _m2 = server
@@ -47,7 +47,7 @@ fn limit_is_clamped() {
         .with_body(json_one_repo())
         .create();
 
-    let _ = search_github_repos_inner(&server.url(), "hello", 999, None).unwrap();
+    let _ = search_github_repos_inner(&server.url(), "hello", 999, None, "").unwrap();
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn maps_fields() {
         .with_body(json_one_repo())
         .create();
 
-    let out = search_github_repos_inner(&server.url(), "x", 2, None).unwrap();
+    let out = search_github_repos_inner(&server.url(), "x", 2, None, "").unwrap();
     assert_eq!(out[0].full_name, "o/r");
     assert_eq!(out[0].stars, 123);
 }
@@ -78,7 +78,7 @@ fn http_error_has_context() {
         .with_body("oops")
         .create();
 
-    let err = search_github_repos_inner(&server.url(), "x", 2, None).unwrap_err();
+    let err = search_github_repos_inner(&server.url(), "x", 2, None, "").unwrap_err();
     let msg = format!("{:#}", err);
     assert!(msg.contains("GitHub search returned error"), "{msg}");
 }

--- a/src-tauri/src/core/tests/system_scheduler.rs
+++ b/src-tauri/src/core/tests/system_scheduler.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use crate::core::system_scheduler::{
+    build_launch_agent_plist, build_systemd_service, build_systemd_timer, launchctl_kickstart_args,
+    scheduler_executable_for_current_exe, summarize_launchctl_status, systemd_start_args,
+    windows_schtasks_args, windows_schtasks_run_args, SchedulerConfig,
+};
+
+#[test]
+fn mac_launch_agent_uses_current_user_interval_and_background_arg() {
+    let plist = build_launch_agent_plist(&SchedulerConfig {
+        executable: Path::new("/Applications/Skills Hub.app/Contents/MacOS/Skills Hub")
+            .to_path_buf(),
+        interval_hours: 24,
+    });
+
+    assert!(plist.contains("<key>StartInterval</key>"));
+    assert!(plist.contains("<integer>86400</integer>"));
+    assert!(plist.contains("--background-task</string>"));
+    assert!(plist.contains("update-skills</string>"));
+    assert!(plist.contains("--force</string>"));
+}
+
+#[test]
+fn debug_scheduler_uses_stable_runner_copy_for_target_debug_binary() {
+    let temp = tempfile::tempdir().unwrap();
+    let debug_dir = temp.path().join("target").join("debug");
+    std::fs::create_dir_all(&debug_dir).unwrap();
+    let app = debug_dir.join("app");
+    std::fs::write(&app, b"runner").unwrap();
+
+    let executable = scheduler_executable_for_current_exe(&app).unwrap();
+
+    if cfg!(debug_assertions) {
+        assert_eq!(executable, debug_dir.join("skills-hub-autoupdate-runner"));
+        assert_eq!(std::fs::read(&executable).unwrap(), b"runner");
+    } else {
+        assert_eq!(executable, app);
+    }
+}
+
+#[test]
+fn mac_kickstart_targets_user_launch_agent() {
+    let args = launchctl_kickstart_args(501);
+
+    assert_eq!(
+        args,
+        vec!["kickstart", "-k", "gui/501/com.skillshub.autoupdate"]
+    );
+}
+
+#[test]
+fn mac_launchctl_status_summary_includes_runtime_state() {
+    let summary = summarize_launchctl_status(
+        r#"
+        state = not running
+        runs = 34
+        last exit code = 0
+        "#,
+    );
+
+    assert_eq!(summary, "state = not running; last exit code = 0");
+}
+
+#[test]
+fn windows_task_uses_hourly_schedule_without_elevated_flag() {
+    let args = windows_schtasks_args(&SchedulerConfig {
+        executable: Path::new("C:\\Users\\may\\AppData\\Local\\SkillsHub\\SkillsHub.exe")
+            .to_path_buf(),
+        interval_hours: 12,
+    });
+
+    assert!(args.iter().any(|v| v == "/SC"));
+    assert!(args.iter().any(|v| v == "HOURLY"));
+    assert!(args.iter().any(|v| v == "/MO"));
+    assert!(args.iter().any(|v| v == "12"));
+    assert!(!args.iter().any(|v| v == "/RL"));
+    assert!(args
+        .iter()
+        .any(|v| v.contains("--background-task update-skills --force")));
+}
+
+#[test]
+fn windows_run_args_start_registered_task() {
+    let args = windows_schtasks_run_args();
+
+    assert_eq!(args, vec!["/Run", "/TN", "com.skillshub.autoupdate"]);
+}
+
+#[test]
+fn linux_systemd_unit_uses_user_timer_interval() {
+    let config = SchedulerConfig {
+        executable: Path::new("/usr/bin/skills-hub").to_path_buf(),
+        interval_hours: 48,
+    };
+
+    let service = build_systemd_service(&config);
+    let timer = build_systemd_timer(&config);
+
+    assert!(
+        service.contains("ExecStart=/usr/bin/skills-hub --background-task update-skills --force")
+    );
+    assert!(timer.contains("OnBootSec=5min"));
+    assert!(timer.contains("OnUnitActiveSec=48h"));
+    assert!(timer.contains("WantedBy=timers.target"));
+}
+
+#[test]
+fn linux_start_args_start_service_for_immediate_test() {
+    let args = systemd_start_args();
+
+    assert_eq!(
+        args,
+        vec!["--user", "start", "com.skillshub.autoupdate.service"]
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,14 @@ use core::skill_store::{default_db_path, migrate_legacy_db_if_needed, SkillStore
 use tauri::Manager;
 use tauri_plugin_log::{Target, TargetKind};
 
+fn init_store<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> anyhow::Result<SkillStore> {
+    let db_path = default_db_path(app)?;
+    migrate_legacy_db_if_needed(&db_path)?;
+    let store = SkillStore::new(db_path);
+    store.ensure_schema()?;
+    Ok(store)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -26,10 +34,45 @@ pub fn run() {
                     .build(),
             )?;
 
-            let db_path = default_db_path(app.handle()).map_err(tauri::Error::from)?;
-            migrate_legacy_db_if_needed(&db_path).map_err(tauri::Error::from)?;
-            let store = SkillStore::new(db_path);
-            store.ensure_schema().map_err(tauri::Error::from)?;
+            let is_background_update = std::env::args()
+                .collect::<Vec<_>>()
+                .windows(2)
+                .any(|pair| pair[0] == "--background-task" && pair[1] == "update-skills");
+            let force_background_update = std::env::args().any(|arg| arg == "--force");
+
+            let store = init_store(app.handle()).map_err(tauri::Error::from)?;
+
+            if is_background_update {
+                #[cfg(target_os = "macos")]
+                {
+                    app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+                }
+                let run_result = if force_background_update {
+                    core::auto_update::run_auto_update_now(app.handle(), &store).map(Some)
+                } else {
+                    core::auto_update::run_due_auto_update(app.handle(), &store)
+                };
+                match run_result {
+                    Ok(Some(result)) => {
+                        log::info!(
+                            "auto update finished: checked={}, updated={}, failed={}",
+                            result.checked,
+                            result.updated,
+                            result.failed
+                        );
+                        app.handle().exit(if result.failed == 0 { 0 } else { 2 });
+                    }
+                    Ok(None) => {
+                        app.handle().exit(0);
+                    }
+                    Err(err) => {
+                        eprintln!("auto update failed: {err:#}");
+                        app.handle().exit(1);
+                    }
+                }
+                return Ok(());
+            }
+
             app.manage(store.clone());
             app.manage(Arc::new(CancelToken::new()));
 
@@ -79,6 +122,10 @@ pub fn run() {
             commands::set_git_cache_cleanup_days,
             commands::set_git_cache_ttl_secs,
             commands::clear_git_cache_now,
+            commands::get_auto_update_config,
+            commands::set_auto_update_config,
+            commands::run_auto_update_now,
+            commands::trigger_auto_update_task_now_cmd,
             commands::get_onboarding_plan,
             commands::install_local,
             commands::list_local_skills_cmd,
@@ -93,6 +140,10 @@ pub fn run() {
             commands::search_github,
             commands::get_github_token,
             commands::set_github_token,
+            commands::get_github_proxy_config,
+            commands::set_github_proxy_config,
+            commands::get_github_proxy_url,
+            commands::set_github_proxy_url,
             commands::import_existing_skill,
             commands::get_managed_skills,
             commands::get_tags,

--- a/src/App.css
+++ b/src/App.css
@@ -2366,6 +2366,123 @@
   color: var(--danger, #ef4444);
 }
 
+.auto-update-progress-modal {
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+}
+
+.auto-update-progress-modal .modal-body {
+  overflow-y: auto;
+}
+
+.auto-update-progress-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+}
+
+.auto-update-progress-stats > div {
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-element);
+}
+
+.auto-update-progress-stats span,
+.auto-update-progress-stats strong {
+  display: block;
+}
+
+.auto-update-progress-stats span {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.auto-update-progress-stats strong {
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.auto-update-progress-runtime {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-muted);
+}
+
+.auto-update-progress-runtime span,
+.auto-update-progress-runtime strong {
+  display: block;
+}
+
+.auto-update-progress-runtime span {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.auto-update-progress-runtime strong {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.auto-update-progress-section {
+  display: grid;
+  gap: 8px;
+}
+
+.auto-update-progress-section h3 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.auto-update-progress-list {
+  display: grid;
+  gap: 6px;
+}
+
+.auto-update-progress-item {
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-app);
+}
+
+.auto-update-progress-name {
+  color: var(--text-primary);
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.auto-update-progress-reason {
+  margin-top: 6px;
+  color: var(--danger, #ef4444);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.auto-update-progress-empty {
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+
 .btn-sm {
   padding: 4px 10px;
   font-size: 12px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,10 @@ import ScopeSyncModal from './components/skills/modals/ScopeSyncModal'
 import SharedDirModal from './components/skills/modals/SharedDirModal'
 import SettingsPage from './components/skills/SettingsPage'
 import {
+  getAutoUpdateToastKey,
+  shouldKeepWaitingForTriggeredAutoUpdate,
+} from './components/skills/autoUpdateSettings'
+import {
   buildInstallSyncJobs,
   filterTargetsForScope,
   getAddedProjectPaths,
@@ -42,8 +46,10 @@ import {
   type InstallScope,
 } from './components/skills/installScope'
 import type {
+  AutoUpdateConfigDto,
   FeaturedSkillDto,
   GitSkillCandidate,
+  GithubProxyConfigDto,
   InstallResultDto,
   LocalSkillCandidate,
   ManagedSkill,
@@ -443,6 +449,24 @@ function App() {
   }, [isTauri, invokeTauri])
 
   useEffect(() => {
+    if (!isTauri) return
+    invokeTauri<GithubProxyConfigDto>('get_github_proxy_config')
+      .then((config) => setGithubProxyConfig(config))
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err))
+      })
+  }, [isTauri, invokeTauri])
+
+  useEffect(() => {
+    if (!isTauri) return
+    invokeTauri<AutoUpdateConfigDto>('get_auto_update_config')
+      .then((config) => setAutoUpdateConfig(config))
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err))
+      })
+  }, [isTauri, invokeTauri])
+
+  useEffect(() => {
     if (isTauri) {
       void loadPlan()
     }
@@ -784,6 +808,47 @@ function App() {
   const [gitCacheCleanupDays, setGitCacheCleanupDays] = useState<number>(30)
   const [gitCacheTtlSecs, setGitCacheTtlSecs] = useState<number>(60)
   const [githubToken, setGithubToken] = useState<string>('')
+  const [githubProxyConfig, setGithubProxyConfig] =
+    useState<GithubProxyConfigDto>({
+      enabled: false,
+      port: 7890,
+      url: '',
+      auto_detected: false,
+    })
+  const [autoUpdateConfig, setAutoUpdateConfig] =
+    useState<AutoUpdateConfigDto | null>(null)
+  const [autoUpdateTriggering, setAutoUpdateTriggering] = useState(false)
+
+  useEffect(() => {
+    if (!isTauri) return
+    if (activeView !== 'settings') return
+    if (autoUpdateConfig?.last_status !== 'running') return
+
+    let cancelled = false
+    const timer = window.setInterval(() => {
+      void invokeTauri<AutoUpdateConfigDto>('get_auto_update_config')
+        .then(async (config) => {
+          if (cancelled) return
+          setAutoUpdateConfig(config)
+          if (config.last_status !== 'running') {
+            await loadManagedSkills()
+          }
+        })
+        .catch(() => {})
+    }, 2000)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
+  }, [
+    activeView,
+    autoUpdateConfig?.last_status,
+    invokeTauri,
+    isTauri,
+    loadManagedSkills,
+  ])
+
   const handlePickStoragePath = useCallback(async () => {
     try {
       if (!isTauri) {
@@ -849,6 +914,137 @@ function App() {
     },
     [invokeTauri, isTauri],
   )
+  const handleGithubProxyConfigChange = useCallback(
+    async (enabled: boolean, port: number) => {
+      const normalizedPort = Math.max(1, Math.min(Math.round(port), 65535))
+      setGithubProxyConfig((prev) => ({
+        ...prev,
+        enabled,
+        port: normalizedPort,
+        url: enabled ? `http://127.0.0.1:${normalizedPort}` : '',
+        auto_detected: false,
+      }))
+      if (!isTauri) return
+      try {
+        const saved = await invokeTauri<GithubProxyConfigDto>(
+          'set_github_proxy_config',
+          {
+            enabled,
+            port: normalizedPort,
+          },
+        )
+        setGithubProxyConfig(saved)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        void invokeTauri<GithubProxyConfigDto>('get_github_proxy_config')
+          .then((config) => setGithubProxyConfig(config))
+          .catch(() => {})
+      }
+    },
+    [invokeTauri, isTauri],
+  )
+  const handleAutoUpdateConfigChange = useCallback(
+    async (enabled: boolean, intervalHours: number) => {
+      const normalized = Math.max(1, Math.min(intervalHours, 24 * 30))
+      const previousEnabled = autoUpdateConfig?.enabled
+      setAutoUpdateConfig((prev) => ({
+        enabled,
+        interval_hours: normalized,
+        local_skill_count: prev?.local_skill_count ?? 0,
+        protected_local_skill_count: prev?.protected_local_skill_count ?? 0,
+        task_registered: prev?.task_registered ?? false,
+        task_status_detail: prev?.task_status_detail ?? '',
+        last_run_at: prev?.last_run_at ?? null,
+        last_started_at: prev?.last_started_at ?? null,
+        last_finished_at: prev?.last_finished_at ?? null,
+        last_status: prev?.last_status ?? null,
+        last_error: prev?.last_error ?? null,
+        last_checked: prev?.last_checked ?? 0,
+        last_updated: prev?.last_updated ?? 0,
+        last_failed: prev?.last_failed ?? 0,
+        progress: prev?.progress ?? {
+          total: 0,
+          succeeded: [],
+          failed: [],
+          running: null,
+          pending: [],
+        },
+      }))
+      if (!isTauri) return
+      try {
+        const updated = await invokeTauri<AutoUpdateConfigDto>(
+          'set_auto_update_config',
+          {
+            enabled,
+            intervalHours: normalized,
+          },
+        )
+        setAutoUpdateConfig(updated)
+        setSuccessToastMessage(t(getAutoUpdateToastKey(previousEnabled, enabled)))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        void invokeTauri<AutoUpdateConfigDto>('get_auto_update_config')
+          .then((config) => setAutoUpdateConfig(config))
+          .catch(() => {})
+      }
+    },
+    [autoUpdateConfig?.enabled, invokeTauri, isTauri, t],
+  )
+  const handleTriggerAutoUpdateTaskNow = useCallback(async () => {
+    if (!isTauri || autoUpdateTriggering) return
+    const triggeredAt = Date.now()
+    setAutoUpdateTriggering(true)
+    setError(null)
+    setAutoUpdateConfig((prev) => prev ? {
+      ...prev,
+      last_run_at: triggeredAt,
+      last_started_at: triggeredAt,
+      last_finished_at: null,
+      last_status: 'running',
+      last_error: null,
+      last_checked: 0,
+      last_updated: 0,
+      last_failed: 0,
+      progress: {
+        total: 0,
+        succeeded: [],
+        failed: [],
+        running: null,
+        pending: [],
+      },
+    } : prev)
+    try {
+      await invokeTauri('trigger_auto_update_task_now_cmd')
+      setSuccessToastMessage(t('autoUpdateTaskTriggered'))
+      let sawRunning = false
+      for (let attempt = 0; attempt < 30; attempt += 1) {
+        await new Promise((resolve) => window.setTimeout(resolve, 2000))
+        const latestConfig = await invokeTauri<AutoUpdateConfigDto>(
+          'get_auto_update_config',
+        )
+        if (latestConfig.last_status === 'running') {
+          sawRunning = true
+        }
+        const keepWaiting = shouldKeepWaitingForTriggeredAutoUpdate(
+          latestConfig,
+          triggeredAt,
+          sawRunning,
+        )
+        if (keepWaiting && latestConfig.last_status !== 'running') {
+          continue
+        }
+        setAutoUpdateConfig(latestConfig)
+        if (!keepWaiting) {
+          await loadManagedSkills()
+          break
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setAutoUpdateTriggering(false)
+    }
+  }, [autoUpdateTriggering, invokeTauri, isTauri, loadManagedSkills, t])
   const handleClearGitCacheNow = useCallback(async () => {
     if (!isTauri) {
       setError(t('errors.notTauri'))
@@ -2499,6 +2695,7 @@ function App() {
             storagePath={storagePath}
             gitCacheCleanupDays={gitCacheCleanupDays}
             gitCacheTtlSecs={gitCacheTtlSecs}
+            autoUpdateConfig={autoUpdateConfig}
             themePreference={themePreference}
             onPickStoragePath={handlePickStoragePath}
             onToggleLanguage={toggleLanguage}
@@ -2508,6 +2705,11 @@ function App() {
             onClearGitCacheNow={handleClearGitCacheNow}
             githubToken={githubToken}
             onGithubTokenChange={handleGithubTokenChange}
+            githubProxyConfig={githubProxyConfig}
+            onGithubProxyConfigChange={handleGithubProxyConfigChange}
+            onAutoUpdateConfigChange={handleAutoUpdateConfigChange}
+            onRunAutoUpdateNow={handleTriggerAutoUpdateTaskNow}
+            autoUpdateTriggering={autoUpdateTriggering}
             onBack={handleCloseSettings}
             t={t}
           />

--- a/src/components/skills/SettingsPage.tsx
+++ b/src/components/skills/SettingsPage.tsx
@@ -1,7 +1,18 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, Clock3, LoaderCircle, X, XCircle } from 'lucide-react'
 import type { TFunction } from 'i18next'
 import type { Update } from '@tauri-apps/plugin-updater'
+import type {
+  AutoUpdateConfigDto,
+  AutoUpdateSkillProgressDto,
+  GithubProxyConfigDto,
+} from './types'
+import {
+  getAutoUpdateProgressCounts,
+  getAutoUpdateTaskStatusKey,
+  isAutoUpdatePossiblyStalled,
+  parseAutoUpdateFailureItems,
+} from './autoUpdateSettings'
 
 type UpdateStatus = 'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'done' | 'error'
 
@@ -11,8 +22,10 @@ type SettingsPageProps = {
   storagePath: string
   gitCacheCleanupDays: number
   gitCacheTtlSecs: number
+  autoUpdateConfig: AutoUpdateConfigDto | null
   themePreference: 'system' | 'light' | 'dark'
   githubToken: string
+  githubProxyConfig: GithubProxyConfigDto
   onPickStoragePath: () => void
   onToggleLanguage: () => void
   onThemeChange: (nextTheme: 'system' | 'light' | 'dark') => void
@@ -20,6 +33,10 @@ type SettingsPageProps = {
   onGitCacheTtlSecsChange: (nextSecs: number) => void
   onClearGitCacheNow: () => void
   onGithubTokenChange: (token: string) => void
+  onGithubProxyConfigChange: (enabled: boolean, port: number) => void
+  onAutoUpdateConfigChange: (enabled: boolean, intervalHours: number) => void
+  onRunAutoUpdateNow: () => void
+  autoUpdateTriggering: boolean
   onBack: () => void
   t: TFunction
 }
@@ -30,6 +47,7 @@ const SettingsPage = ({
   storagePath,
   gitCacheCleanupDays,
   gitCacheTtlSecs,
+  autoUpdateConfig,
   themePreference,
   onPickStoragePath,
   onToggleLanguage,
@@ -39,6 +57,11 @@ const SettingsPage = ({
   onClearGitCacheNow,
   githubToken,
   onGithubTokenChange,
+  githubProxyConfig,
+  onGithubProxyConfigChange,
+  onAutoUpdateConfigChange,
+  onRunAutoUpdateNow,
+  autoUpdateTriggering,
   onBack,
   t,
 }: SettingsPageProps) => {
@@ -46,6 +69,17 @@ const SettingsPage = ({
   useEffect(() => {
     setLocalToken(githubToken)
   }, [githubToken])
+  const [localGithubProxyPort, setLocalGithubProxyPort] = useState(
+    String(githubProxyConfig.port),
+  )
+  useEffect(() => {
+    setLocalGithubProxyPort(String(githubProxyConfig.port))
+  }, [githubProxyConfig.port])
+  const [localAutoUpdateInterval, setLocalAutoUpdateInterval] = useState(24)
+  useEffect(() => {
+    setLocalAutoUpdateInterval(autoUpdateConfig?.interval_hours ?? 24)
+  }, [autoUpdateConfig?.interval_hours])
+  const [autoUpdateProgressOpen, setAutoUpdateProgressOpen] = useState(false)
 
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('idle')
   const [updateVersion, setUpdateVersion] = useState<string | null>(null)
@@ -111,6 +145,117 @@ const SettingsPage = ({
     void loadAppVersion()
     return () => { updateRef.current = null }
   }, [loadAppVersion])
+
+  const autoUpdateEnabled = autoUpdateConfig?.enabled ?? false
+  const autoUpdateInterval = autoUpdateConfig?.interval_hours ?? 24
+  const autoUpdateHasLocalSkills = (autoUpdateConfig?.local_skill_count ?? 0) > 0
+  const autoUpdateHasProtectedLocalSkills =
+    (autoUpdateConfig?.protected_local_skill_count ?? 0) > 0
+  const autoUpdateRunning = autoUpdateConfig?.last_status === 'running'
+  const autoUpdateRunningLong =
+    autoUpdateRunning &&
+    Boolean(autoUpdateConfig?.last_run_at) &&
+    Date.now() - (autoUpdateConfig?.last_run_at ?? 0) > 10 * 60 * 1000
+  const autoUpdateStalled = isAutoUpdatePossiblyStalled(autoUpdateConfig, Date.now())
+  const autoUpdateButtonBusy =
+    (autoUpdateRunning && !autoUpdateStalled) || autoUpdateTriggering
+  const autoUpdateLastRun = autoUpdateConfig?.last_run_at
+    ? new Date(autoUpdateConfig.last_run_at).toLocaleString()
+    : t('autoUpdateNeverRun')
+  const autoUpdateStartedAt = autoUpdateConfig?.last_started_at
+    ? new Date(autoUpdateConfig.last_started_at).toLocaleString()
+    : t('autoUpdateNeverRun')
+  const autoUpdateFinishedAt = autoUpdateConfig?.last_finished_at
+    ? new Date(autoUpdateConfig.last_finished_at).toLocaleString()
+    : autoUpdateRunning
+      ? t('autoUpdateStatus.running')
+      : t('autoUpdateNeverRun')
+  const autoUpdateDuration =
+    autoUpdateConfig?.last_started_at && autoUpdateConfig?.last_finished_at
+      ? formatDuration(autoUpdateConfig.last_finished_at - autoUpdateConfig.last_started_at)
+      : autoUpdateRunning && autoUpdateConfig?.last_started_at
+        ? formatDuration(Date.now() - autoUpdateConfig.last_started_at)
+        : t('autoUpdateNeverRun')
+  const autoUpdateStatus = autoUpdateConfig?.last_status
+    ? t(`autoUpdateStatus.${autoUpdateConfig.last_status}`)
+    : t('autoUpdateStatus.none')
+  const taskStatusKey = getAutoUpdateTaskStatusKey(
+    autoUpdateEnabled,
+    autoUpdateConfig?.task_registered ?? false,
+  )
+  const autoUpdateProgress = autoUpdateConfig?.progress
+  const autoUpdateProgressForDisplay = useMemo(() => {
+    const hasStructuredProgress =
+      Boolean(autoUpdateProgress?.total) ||
+      Boolean(autoUpdateProgress?.succeeded.length) ||
+      Boolean(autoUpdateProgress?.failed.length) ||
+      Boolean(autoUpdateProgress?.running) ||
+      Boolean(autoUpdateProgress?.pending.length)
+    if (autoUpdateProgress && hasStructuredProgress) {
+      return autoUpdateProgress
+    }
+
+    return {
+      total: autoUpdateConfig?.last_checked ?? 0,
+      succeeded: [],
+      failed: parseAutoUpdateFailureItems(autoUpdateConfig?.last_error),
+      running: null,
+      pending: [],
+    }
+  }, [
+    autoUpdateConfig?.last_checked,
+    autoUpdateConfig?.last_error,
+    autoUpdateProgress,
+  ])
+  const rawAutoUpdateProgressCounts = getAutoUpdateProgressCounts(
+    autoUpdateProgressForDisplay,
+  )
+  const autoUpdateCompletedCount =
+    (autoUpdateConfig?.last_updated ?? 0) + (autoUpdateConfig?.last_failed ?? 0)
+  const autoUpdateProgressCounts = {
+    total: autoUpdateConfig?.last_checked || rawAutoUpdateProgressCounts.total,
+    completed: autoUpdateCompletedCount || rawAutoUpdateProgressCounts.completed,
+    succeeded: autoUpdateConfig?.last_updated ?? rawAutoUpdateProgressCounts.succeeded,
+    failed: autoUpdateConfig?.last_failed ?? rawAutoUpdateProgressCounts.failed,
+    active: Math.max(
+      0,
+      (autoUpdateConfig?.last_checked || rawAutoUpdateProgressCounts.total) -
+        (autoUpdateCompletedCount || rawAutoUpdateProgressCounts.completed),
+    ),
+  }
+  const autoUpdatePendingCount =
+    autoUpdateProgressForDisplay.pending.length ||
+    Math.max(
+      0,
+      autoUpdateProgressCounts.active -
+        (autoUpdateProgressForDisplay.running ? 1 : 0),
+    )
+  const handleCopyAutoUpdateError = useCallback(async () => {
+    if (!autoUpdateConfig?.last_error) return
+    await navigator.clipboard.writeText(autoUpdateConfig.last_error)
+  }, [autoUpdateConfig?.last_error])
+  const renderProgressItems = (
+    items: AutoUpdateSkillProgressDto[],
+    emptyKey: string,
+    showReason = false,
+  ) => {
+    if (items.length === 0) {
+      return <div className="auto-update-progress-empty">{t(emptyKey)}</div>
+    }
+
+    return (
+      <div className="auto-update-progress-list">
+        {items.map((item) => (
+          <div className="auto-update-progress-item" key={item.skill_id}>
+            <div className="auto-update-progress-name">{item.name || item.skill_id}</div>
+            {showReason && item.reason ? (
+              <div className="auto-update-progress-reason">{item.reason}</div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    )
+  }
 
   return (
     <div className="settings-page">
@@ -290,6 +435,302 @@ const SettingsPage = ({
           <div className="settings-helper">{t('githubTokenHint')}</div>
         </div>
 
+        <div className="settings-field">
+          <div className="settings-item">
+            <div className="settings-item-info">
+              <div className="settings-item-title">{t('networkProxy')}</div>
+              <div className="settings-item-desc">{t('networkProxyHint')}</div>
+            </div>
+            <button
+              type="button"
+              className={`settings-toggle${githubProxyConfig.enabled ? ' checked' : ''}`}
+              aria-pressed={githubProxyConfig.enabled}
+              onClick={() => {
+                const nextPort = Number(localGithubProxyPort)
+                onGithubProxyConfigChange(
+                  !githubProxyConfig.enabled,
+                  Number.isNaN(nextPort) ? githubProxyConfig.port : nextPort,
+                )
+              }}
+            >
+              <span className="settings-toggle-knob" />
+            </button>
+          </div>
+          <label className="settings-label" htmlFor="settings-github-proxy-port">
+            {t('networkProxyPort')}
+          </label>
+          <div className="settings-input-row">
+            <input
+              id="settings-github-proxy-port"
+              className="settings-input mono"
+              type="number"
+              min={1}
+              max={65535}
+              step={1}
+              value={localGithubProxyPort}
+              onChange={(e) => setLocalGithubProxyPort(e.target.value)}
+              onBlur={() => {
+                const nextPort = Number(localGithubProxyPort)
+                if (
+                  githubProxyConfig.enabled &&
+                  !Number.isNaN(nextPort) &&
+                  nextPort !== githubProxyConfig.port
+                ) {
+                  onGithubProxyConfigChange(true, nextPort)
+                }
+              }}
+            />
+          </div>
+          <div className="settings-helper">
+            {githubProxyConfig.auto_detected
+              ? t('networkProxyAutoDetected')
+              : t('networkProxyPortHint')}
+          </div>
+        </div>
+
+        <div className="settings-field">
+          <label className="settings-label">{t('autoUpdateSkills')}</label>
+          <div className="settings-item">
+            <div className="settings-item-info">
+              <div className="settings-item-title">{t('autoUpdateSystemTask')}</div>
+              <div className="settings-item-desc">
+                {t('autoUpdateSystemTaskDesc')}
+              </div>
+            </div>
+            <button
+              type="button"
+              className={`settings-toggle${autoUpdateEnabled ? ' checked' : ''}`}
+              aria-pressed={autoUpdateEnabled}
+              onClick={() => {
+                onAutoUpdateConfigChange(
+                  !autoUpdateEnabled,
+                  localAutoUpdateInterval,
+                )
+              }}
+            >
+              <span className="settings-toggle-knob" />
+            </button>
+          </div>
+          <div className="settings-input-row">
+            <input
+              id="settings-auto-update-hours"
+              className="settings-input"
+              type="number"
+              min={1}
+              max={720}
+              step={1}
+              value={localAutoUpdateInterval}
+              onChange={(event) => {
+                const next = Number(event.target.value)
+                if (!Number.isNaN(next)) {
+                  setLocalAutoUpdateInterval(next)
+                }
+              }}
+              onBlur={() => {
+                if (localAutoUpdateInterval !== autoUpdateInterval) {
+                  onAutoUpdateConfigChange(
+                    autoUpdateEnabled,
+                    localAutoUpdateInterval,
+                  )
+                }
+              }}
+            />
+            <button
+              className="btn btn-secondary settings-browse"
+              type="button"
+              disabled={autoUpdateButtonBusy}
+              onClick={onRunAutoUpdateNow}
+            >
+              {autoUpdateButtonBusy
+                ? t('autoUpdateRunningButton')
+                : autoUpdateStalled
+                  ? t('autoUpdateRetryUpdate')
+                  : t('autoUpdateRunNow')}
+            </button>
+          </div>
+          <div className="settings-helper">
+            {t('autoUpdateIntervalHint', { hours: autoUpdateInterval })}
+          </div>
+          {autoUpdateHasLocalSkills ? (
+            <div className="settings-helper">
+              {t(
+                autoUpdateHasProtectedLocalSkills
+                  ? 'autoUpdateLocalPermissionProtectedHint'
+                  : 'autoUpdateLocalPermissionHint',
+              )}
+            </div>
+          ) : null}
+          <div className="settings-helper">
+            {t('autoUpdateTaskStatus', { status: t(taskStatusKey) })}
+          </div>
+          {taskStatusKey === 'autoUpdateTaskNeedsAttention' ? (
+            <div className="settings-helper">
+              {t('autoUpdateTaskNeedsAttentionHint')}
+            </div>
+          ) : null}
+          <div className="settings-helper">
+            {t('autoUpdateLastRun', {
+              time: autoUpdateLastRun,
+              status: autoUpdateStatus,
+              checked: autoUpdateConfig?.last_checked ?? 0,
+              updated: autoUpdateConfig?.last_updated ?? 0,
+              failed: autoUpdateConfig?.last_failed ?? 0,
+            })}
+          </div>
+          <div className="settings-helper">
+            <button
+              className="btn btn-secondary btn-sm"
+              type="button"
+              onClick={() => setAutoUpdateProgressOpen(true)}
+            >
+              {t('autoUpdateViewProgress')}
+            </button>
+          </div>
+          {autoUpdateStalled ? (
+            <div className="settings-helper">
+              {t('autoUpdateStalledHint')}
+            </div>
+          ) : autoUpdateRunningLong ? (
+            <div className="settings-helper">
+              {t('autoUpdateLongRunningHint')}
+            </div>
+          ) : null}
+          {autoUpdateProgressOpen ? (
+            <div
+              className="modal-backdrop"
+              onClick={() => setAutoUpdateProgressOpen(false)}
+            >
+              <div
+                className="modal modal-lg auto-update-progress-modal"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="modal-header">
+                  <div className="modal-title">{t('autoUpdateProgressTitle')}</div>
+                  <button
+                    className="modal-close"
+                    type="button"
+                    onClick={() => setAutoUpdateProgressOpen(false)}
+                    aria-label={t('close')}
+                  >
+                    <X size={18} />
+                  </button>
+                </div>
+                <div className="modal-body">
+                  <div className="auto-update-progress-stats">
+                    <div>
+                      <span>{t('autoUpdateProgressTotal')}</span>
+                      <strong>{autoUpdateProgressCounts.total}</strong>
+                    </div>
+                    <div>
+                      <span>{t('autoUpdateProgressSucceeded')}</span>
+                      <strong>{autoUpdateProgressCounts.succeeded}</strong>
+                    </div>
+                    <div>
+                      <span>{t('autoUpdateProgressFailed')}</span>
+                      <strong>{autoUpdateProgressCounts.failed}</strong>
+                    </div>
+                    <div>
+                      <span>{t('autoUpdateProgressActive')}</span>
+                      <strong>{autoUpdateProgressCounts.active}</strong>
+                    </div>
+                  </div>
+                  <div className="auto-update-progress-runtime">
+                    <div>
+                      <span>{t('autoUpdateProgressStartedAt')}</span>
+                      <strong>{autoUpdateStartedAt}</strong>
+                    </div>
+                    <div>
+                      <span>{t('autoUpdateProgressFinishedAt')}</span>
+                      <strong>{autoUpdateFinishedAt}</strong>
+                    </div>
+                    <div>
+                      <span>{t('autoUpdateProgressDuration')}</span>
+                      <strong>{autoUpdateDuration}</strong>
+                    </div>
+                  </div>
+
+                  <section className="auto-update-progress-section">
+                    <h3>
+                      <LoaderCircle size={16} />
+                      {t('autoUpdateProgressRunning')}
+                    </h3>
+                    {autoUpdateProgressForDisplay.running ? (
+                      <div className="auto-update-progress-list">
+                        <div className="auto-update-progress-item">
+                          <div className="auto-update-progress-name">
+                            {autoUpdateProgressForDisplay.running.name ||
+                              autoUpdateProgressForDisplay.running.skill_id}
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="auto-update-progress-empty">
+                        {autoUpdateProgressCounts.active > 0
+                          ? t('autoUpdateProgressWaitingToStart')
+                          : t('autoUpdateProgressNoRunning')}
+                      </div>
+                    )}
+                  </section>
+
+                  <section className="auto-update-progress-section">
+                    <h3>
+                      <XCircle size={16} />
+                      {t('autoUpdateProgressFailed')}
+                    </h3>
+                    {renderProgressItems(
+                      autoUpdateProgressForDisplay.failed,
+                      'autoUpdateProgressNoFailed',
+                      true,
+                    )}
+                  </section>
+
+                  <section className="auto-update-progress-section">
+                    <h3>
+                      <CheckCircle2 size={16} />
+                      {t('autoUpdateProgressSucceeded')}
+                    </h3>
+                    <div className="auto-update-progress-empty">
+                      {autoUpdateProgressCounts.succeeded > 0
+                        ? t('autoUpdateProgressSucceededSummary', {
+                            count: autoUpdateProgressCounts.succeeded,
+                          })
+                        : t('autoUpdateProgressNoSucceeded')}
+                    </div>
+                  </section>
+
+                  <section className="auto-update-progress-section">
+                    <h3>
+                      <Clock3 size={16} />
+                      {t('autoUpdateProgressPending')}
+                    </h3>
+                    <div className="auto-update-progress-empty">
+                      {autoUpdatePendingCount > 0
+                        ? t('autoUpdateProgressPendingSummary', {
+                            count: autoUpdatePendingCount,
+                          })
+                        : t('autoUpdateProgressNoPending')}
+                    </div>
+                  </section>
+
+                  {autoUpdateConfig?.last_error ? (
+                    <div className="modal-actions">
+                      <button
+                        className="btn btn-secondary btn-sm"
+                        type="button"
+                        onClick={() => {
+                          void handleCopyAutoUpdateError()
+                        }}
+                      >
+                        {t('copyDetails')}
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
         <div className="settings-field settings-update-section">
           <label className="settings-label">{t('appUpdates')}</label>
           <div className="settings-version-row">
@@ -348,6 +789,20 @@ const SettingsPage = ({
       </div>
     </div>
   )
+}
+
+function formatDuration(durationMs: number) {
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`
+  }
+  return `${seconds}s`
 }
 
 export default memo(SettingsPage)

--- a/src/components/skills/autoUpdateSettings.test.ts
+++ b/src/components/skills/autoUpdateSettings.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getAutoUpdateProgressCounts,
+  getAutoUpdateTaskStatusKey,
+  getAutoUpdateToastKey,
+  isAutoUpdatePossiblyStalled,
+  parseAutoUpdateFailureItems,
+  shouldKeepWaitingForTriggeredAutoUpdate,
+  summarizeAutoUpdateErrors,
+} from './autoUpdateSettings'
+
+describe('getAutoUpdateToastKey', () => {
+  it('uses enable and disable messages only when the toggle changes', () => {
+    expect(getAutoUpdateToastKey(false, true)).toBe('autoUpdateEnabled')
+    expect(getAutoUpdateToastKey(true, false)).toBe('autoUpdateDisabled')
+  })
+
+  it('uses a neutral saved message when only the interval changes', () => {
+    expect(getAutoUpdateToastKey(false, false)).toBe('autoUpdateConfigSaved')
+    expect(getAutoUpdateToastKey(true, true)).toBe('autoUpdateConfigSaved')
+  })
+})
+
+describe('summarizeAutoUpdateErrors', () => {
+  it('groups noisy raw update errors into user-facing categories', () => {
+    const result = summarizeAutoUpdateErrors([
+      's1: source path not found: "/Users/may/Downloads/demo"',
+      's2: git 命令执行失败。git 操作超时 (300s)。error: RPC failed; curl 28 Operation too slow',
+      's3: fatal: unable to access github.com port 443',
+    ].join('\n'))
+
+    expect(result.total).toBe(3)
+    expect(result.summaries).toEqual([
+      { key: 'autoUpdateErrorSourceMissing', count: 1 },
+      { key: 'autoUpdateErrorNetwork', count: 2 },
+    ])
+  })
+
+  it('returns no summaries for empty errors', () => {
+    expect(summarizeAutoUpdateErrors('').summaries).toEqual([])
+  })
+})
+
+describe('getAutoUpdateTaskStatusKey', () => {
+  it('hides registration details when auto-update is off', () => {
+    expect(getAutoUpdateTaskStatusKey(false, false)).toBe('autoUpdateTaskOff')
+    expect(getAutoUpdateTaskStatusKey(false, true)).toBe('autoUpdateTaskOff')
+  })
+
+  it('shows user-level readiness instead of platform implementation details', () => {
+    expect(getAutoUpdateTaskStatusKey(true, true)).toBe('autoUpdateTaskReady')
+    expect(getAutoUpdateTaskStatusKey(true, false)).toBe(
+      'autoUpdateTaskNeedsAttention',
+    )
+  })
+})
+
+describe('getAutoUpdateProgressCounts', () => {
+  it('counts completed and remaining structured progress items', () => {
+    expect(getAutoUpdateProgressCounts({
+      total: 4,
+      succeeded: [{ skill_id: 'a', name: 'A' }],
+      failed: [{ skill_id: 'b', name: 'B', reason: 'network timeout' }],
+      running: { skill_id: 'c', name: 'C' },
+      pending: [{ skill_id: 'd', name: 'D' }],
+    })).toEqual({
+      total: 4,
+      completed: 2,
+      succeeded: 1,
+      failed: 1,
+      active: 2,
+    })
+  })
+})
+
+describe('parseAutoUpdateFailureItems', () => {
+  it('extracts failed skill ids and reasons from legacy raw error text', () => {
+    expect(parseAutoUpdateFailureItems([
+      'skill-a: source path not found: "/tmp/a"',
+      'skill-b: git clone failed',
+    ].join('\n'))).toEqual([
+      {
+        skill_id: 'skill-a',
+        name: 'skill-a',
+        reason: 'source path not found: "/tmp/a"',
+      },
+      {
+        skill_id: 'skill-b',
+        name: 'skill-b',
+        reason: 'git clone failed',
+      },
+    ])
+  })
+})
+
+describe('shouldKeepWaitingForTriggeredAutoUpdate', () => {
+  it('keeps waiting when polling still sees an old completed run', () => {
+    expect(shouldKeepWaitingForTriggeredAutoUpdate(
+      { last_status: 'error', last_run_at: 1_000 },
+      2_000,
+      false,
+    )).toBe(true)
+  })
+
+  it('keeps waiting while the triggered run is running', () => {
+    expect(shouldKeepWaitingForTriggeredAutoUpdate(
+      { last_status: 'running', last_run_at: 2_000 },
+      2_000,
+      false,
+    )).toBe(true)
+  })
+
+  it('stops after a run has been observed running and then completes', () => {
+    expect(shouldKeepWaitingForTriggeredAutoUpdate(
+      { last_status: 'ok', last_run_at: 3_000 },
+      2_000,
+      true,
+    )).toBe(false)
+  })
+
+  it('stops when the latest completed run started after the trigger', () => {
+    expect(shouldKeepWaitingForTriggeredAutoUpdate(
+      { last_status: 'error', last_run_at: 2_500 },
+      2_000,
+      false,
+    )).toBe(false)
+  })
+})
+
+describe('isAutoUpdatePossiblyStalled', () => {
+  it('detects a long-running update with no current item and no progress', () => {
+    expect(isAutoUpdatePossiblyStalled({
+      last_status: 'running',
+      last_run_at: 1_000,
+      last_updated: 0,
+      last_failed: 0,
+      progress: {
+        total: 60,
+        succeeded: [],
+        failed: [],
+        running: null,
+        pending: [],
+      },
+    }, 1_000 + 11 * 60 * 1000)).toBe(true)
+  })
+
+  it('does not mark a run with an active current item as stalled', () => {
+    expect(isAutoUpdatePossiblyStalled({
+      last_status: 'running',
+      last_run_at: 1_000,
+      last_updated: 0,
+      last_failed: 0,
+      progress: {
+        total: 60,
+        succeeded: [],
+        failed: [],
+        running: { skill_id: 'a', name: 'A' },
+        pending: [],
+      },
+    }, 1_000 + 11 * 60 * 1000)).toBe(false)
+  })
+})

--- a/src/components/skills/autoUpdateSettings.ts
+++ b/src/components/skills/autoUpdateSettings.ts
@@ -1,0 +1,172 @@
+import type {
+  AutoUpdateConfigDto,
+  AutoUpdateProgressSnapshotDto,
+  AutoUpdateSkillProgressDto,
+} from './types'
+
+export type AutoUpdateToastKey =
+  | 'autoUpdateEnabled'
+  | 'autoUpdateDisabled'
+  | 'autoUpdateConfigSaved'
+
+export type AutoUpdateTaskStatusKey =
+  | 'autoUpdateTaskOff'
+  | 'autoUpdateTaskReady'
+  | 'autoUpdateTaskNeedsAttention'
+
+export function getAutoUpdateToastKey(
+  previousEnabled: boolean | null | undefined,
+  nextEnabled: boolean,
+): AutoUpdateToastKey {
+  if (previousEnabled === true && !nextEnabled) {
+    return 'autoUpdateDisabled'
+  }
+  if (previousEnabled === false && nextEnabled) {
+    return 'autoUpdateEnabled'
+  }
+  return 'autoUpdateConfigSaved'
+}
+
+export function getAutoUpdateTaskStatusKey(
+  enabled: boolean,
+  taskRegistered: boolean,
+): AutoUpdateTaskStatusKey {
+  if (!enabled) {
+    return 'autoUpdateTaskOff'
+  }
+  if (taskRegistered) {
+    return 'autoUpdateTaskReady'
+  }
+  return 'autoUpdateTaskNeedsAttention'
+}
+
+export type AutoUpdateErrorSummary = {
+  key: string
+  count: number
+}
+
+export function summarizeAutoUpdateErrors(rawError: string | null | undefined) {
+  const lines = (rawError ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  const summaries = new Map<string, number>()
+  for (const line of lines) {
+    const key = classifyAutoUpdateError(line)
+    summaries.set(key, (summaries.get(key) ?? 0) + 1)
+  }
+
+  return {
+    total: lines.length,
+    summaries: Array.from(summaries.entries()).map(([key, count]) => ({
+      key,
+      count,
+    })),
+  }
+}
+
+export function getAutoUpdateProgressCounts(
+  progress: AutoUpdateProgressSnapshotDto | null | undefined,
+) {
+  const succeeded = progress?.succeeded.length ?? 0
+  const failed = progress?.failed.length ?? 0
+  const total = progress?.total ?? succeeded + failed
+  const running = progress?.running ? 1 : 0
+  const pending = progress?.pending.length ?? Math.max(0, total - succeeded - failed - running)
+
+  return {
+    total,
+    completed: succeeded + failed,
+    succeeded,
+    failed,
+    active: running + pending,
+  }
+}
+
+export function parseAutoUpdateFailureItems(
+  rawError: string | null | undefined,
+): AutoUpdateSkillProgressDto[] {
+  return (rawError ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const separatorIndex = line.indexOf(':')
+      if (separatorIndex <= 0) {
+        return {
+          skill_id: line,
+          name: line,
+          reason: line,
+        }
+      }
+      const skillId = line.slice(0, separatorIndex).trim()
+      const reason = line.slice(separatorIndex + 1).trim()
+      return {
+        skill_id: skillId,
+        name: skillId,
+        reason,
+      }
+    })
+}
+
+export function shouldKeepWaitingForTriggeredAutoUpdate(
+  config: Pick<AutoUpdateConfigDto, 'last_run_at' | 'last_status'>,
+  triggeredAtMs: number,
+  sawRunning: boolean,
+) {
+  if (config.last_status === 'running') {
+    return true
+  }
+  if (sawRunning) {
+    return false
+  }
+  if (typeof config.last_run_at === 'number' && config.last_run_at >= triggeredAtMs) {
+    return false
+  }
+  return true
+}
+
+export function isAutoUpdatePossiblyStalled(
+  config: Pick<
+    AutoUpdateConfigDto,
+    'last_run_at' | 'last_status' | 'last_updated' | 'last_failed' | 'progress'
+  > | null | undefined,
+  nowMs: number,
+  staleAfterMs = 10 * 60 * 1000,
+) {
+  if (!config?.last_run_at || config.last_status !== 'running') {
+    return false
+  }
+  const completed = config.last_updated + config.last_failed
+  return (
+    nowMs - config.last_run_at > staleAfterMs &&
+    completed === 0 &&
+    !config.progress?.running
+  )
+}
+
+function classifyAutoUpdateError(line: string) {
+  const lower = line.toLowerCase()
+  if (
+    lower.includes('source path not found') ||
+    lower.includes('central path not found')
+  ) {
+    return 'autoUpdateErrorSourceMissing'
+  }
+  if (
+    lower.includes('failed to connect to github.com') ||
+    lower.includes('unable to access') ||
+    lower.includes('operation too slow') ||
+    lower.includes('unexpected disconnect') ||
+    lower.includes('early eof') ||
+    lower.includes('git operation timed out') ||
+    lower.includes('git 命令执行失败')
+  ) {
+    return 'autoUpdateErrorNetwork'
+  }
+  if (lower.includes('rate limit')) {
+    return 'autoUpdateErrorRateLimited'
+  }
+  return 'autoUpdateErrorOther'
+}

--- a/src/components/skills/types.ts
+++ b/src/components/skills/types.ts
@@ -105,6 +105,53 @@ export type UpdateResultDto = {
   updated_targets: string[]
 }
 
+export type AutoUpdateConfigDto = {
+  enabled: boolean
+  interval_hours: number
+  local_skill_count: number
+  protected_local_skill_count: number
+  task_registered: boolean
+  task_status_detail: string
+  last_run_at?: number | null
+  last_started_at?: number | null
+  last_finished_at?: number | null
+  last_status?: string | null
+  last_error?: string | null
+  last_checked: number
+  last_updated: number
+  last_failed: number
+  progress: AutoUpdateProgressSnapshotDto
+}
+
+export type AutoUpdateRunResultDto = {
+  checked: number
+  updated: number
+  failed: number
+  errors: string[]
+  progress: AutoUpdateProgressSnapshotDto
+}
+
+export type GithubProxyConfigDto = {
+  enabled: boolean
+  port: number
+  url: string
+  auto_detected: boolean
+}
+
+export type AutoUpdateSkillProgressDto = {
+  skill_id: string
+  name: string
+  reason?: string | null
+}
+
+export type AutoUpdateProgressSnapshotDto = {
+  total: number
+  succeeded: AutoUpdateSkillProgressDto[]
+  failed: AutoUpdateSkillProgressDto[]
+  running?: AutoUpdateSkillProgressDto | null
+  pending: AutoUpdateSkillProgressDto[]
+}
+
 export type FeaturedSkillDto = {
   slug: string
   name: string

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -162,9 +162,87 @@ export const resources = {
       githubTokenPlaceholder: 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
       githubTokenHint:
         'Optional. Set a GitHub personal access token to increase API rate limits from 60/hr to 5,000/hr.',
+      networkProxy: 'Network proxy',
+      networkProxyHint:
+        'Use a local proxy for GitHub API and Git updates. If port 7890 is detected on first launch, this is enabled automatically.',
+      networkProxyPort: 'Proxy port',
+      networkProxyPortHint:
+        'Change this only if your local proxy uses another port.',
+      networkProxyAutoDetected:
+        'Detected local proxy port 7890 and enabled the network proxy automatically.',
       appUpdates: 'App updates',
       updateHint: 'Click “Check” to look for updates.',
       checkForUpdates: 'Check',
+      autoUpdateSystemTask: 'System scheduled update',
+      autoUpdateSystemTaskDesc:
+        'Register a current-user scheduled task to update Git and local skills when the app is closed.',
+      autoUpdateIntervalHint:
+        'Runs every {{hours}} hour(s). Default is 24 hours.',
+      autoUpdateLocalPermissionHint:
+        'Local skills read their original source folder during updates. macOS may ask for file access the first time; Git skills usually do not need this permission.',
+      autoUpdateLocalPermissionProtectedHint:
+        'Some local skill sources are in Desktop, Downloads, or Documents. macOS may ask for folder access when updating them; after you allow it, it is usually remembered.',
+      autoUpdateRunNow: 'Update Now',
+      autoUpdateRetryUpdate: 'Retry Update',
+      autoUpdateRunningButton: 'Updating...',
+      autoUpdateNeverRun: 'Never',
+      autoUpdateLastRun:
+        'Last run: {{time}} · {{status}} · checked {{checked}}, updated {{updated}}, failed {{failed}}',
+      autoUpdateLongRunningHint:
+        'Still running for a long time. This is usually caused by a slow GitHub/network operation or a repository timeout; wait for the current timeout to finish, or try again later.',
+      autoUpdateStalledHint:
+        'This update has not reported progress for a while. The background task may have stopped; you can retry now.',
+      autoUpdateTaskStatus: 'Background update: {{status}}',
+      autoUpdateTaskOff: 'Off',
+      autoUpdateTaskReady: 'Ready',
+      autoUpdateTaskNeedsAttention: 'Needs attention',
+      autoUpdateTaskNeedsAttentionHint:
+        'The system task is not ready. Turn auto-update off and on again, or check app logs for details.',
+      autoUpdateEnabled: 'Auto-update enabled.',
+      autoUpdateDisabled: 'Auto-update disabled.',
+      autoUpdateConfigSaved: 'Auto-update settings saved.',
+      autoUpdateTaskTesting: 'Starting background update...',
+      autoUpdateTaskTriggered:
+        'Background update started. The result will appear here when it finishes.',
+      autoUpdateErrorSummary:
+        '{{count}} skill(s) failed to update. Fix the items below, then run update again.',
+      autoUpdateErrorSourceMissing:
+        '{{count}} local source folder(s) no longer exist. Reconnect or remove those skills.',
+      autoUpdateErrorNetwork:
+        '{{count}} Git update(s) failed because GitHub or the network was unreachable.',
+      autoUpdateErrorRateLimited:
+        '{{count}} GitHub request(s) were rate limited. Add a GitHub Token or try later.',
+      autoUpdateErrorOther:
+        '{{count}} update(s) failed for other reasons.',
+      autoUpdateViewProgress: 'View Progress',
+      autoUpdateProgressTitle: 'Auto-update progress',
+      autoUpdateProgressTotal: 'Total',
+      autoUpdateProgressSucceeded: 'Succeeded',
+      autoUpdateProgressFailed: 'Failed',
+      autoUpdateProgressActive: 'Waiting/Running',
+      autoUpdateProgressStartedAt: 'Started',
+      autoUpdateProgressFinishedAt: 'Finished',
+      autoUpdateProgressDuration: 'Duration',
+      autoUpdateProgressRunning: 'Current item',
+      autoUpdateProgressPending: 'Waiting',
+      autoUpdateProgressNoRunning: 'No skill is running right now.',
+      autoUpdateProgressWaitingToStart:
+        'The background task has started and is waiting to process the first skill.',
+      autoUpdateProgressNoFailed: 'No failed skills.',
+      autoUpdateProgressNoSucceeded: 'No successful skills yet.',
+      autoUpdateProgressSucceededSummary:
+        '{{count}} skill(s) updated successfully.',
+      autoUpdateProgressPendingSummary:
+        '{{count}} skill(s) waiting to update.',
+      autoUpdateProgressNoPending: 'No waiting skills.',
+      copyDetails: 'Copy Details',
+      autoUpdateStatus: {
+        none: 'No run yet',
+        running: 'Running',
+        stopped: 'Stopped',
+        ok: 'Succeeded',
+        error: 'Completed with errors',
+      },
       downloadAndInstall: 'Download & Install',
       checkingUpdates: 'Checking...',
       updateNotAvailable: "You're up to date.",
@@ -543,9 +621,82 @@ export const resources = {
       githubTokenPlaceholder: 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
       githubTokenHint:
         '可选。设置 GitHub 个人访问令牌，可将 API 速率限制从 60 次/小时提升到 5,000 次/小时。',
+      networkProxy: '网络代理',
+      networkProxyHint:
+        '为 GitHub API 和 Git 更新使用本地代理。首次启动检测到 7890 端口时会自动开启。',
+      networkProxyPort: '代理端口',
+      networkProxyPortHint:
+        '只有本地代理使用其他端口时才需要修改。',
+      networkProxyAutoDetected:
+        '已检测到本地代理端口 7890，并自动开启网络代理。',
       appUpdates: '应用更新',
       updateHint: '点击“检查更新”获取最新版本。',
       checkForUpdates: '检查更新',
+      autoUpdateSystemTask: '系统定时更新',
+      autoUpdateSystemTaskDesc:
+        '注册当前用户级系统定时任务，在应用关闭时也更新 Git 和本地 Skills。',
+      autoUpdateIntervalHint: '每 {{hours}} 小时运行一次，默认 24 小时。',
+      autoUpdateLocalPermissionHint:
+        '本地 Skill 更新时会读取原始来源目录，macOS 可能在首次访问时请求文件权限；Git Skill 通常不需要这个授权。',
+      autoUpdateLocalPermissionProtectedHint:
+        '部分本地 Skill 来源位于桌面、下载或文稿目录。更新这些 Skill 时 macOS 可能请求文件夹访问权限；允许后通常会记住。',
+      autoUpdateRunNow: '立即更新',
+      autoUpdateRetryUpdate: '重新更新',
+      autoUpdateRunningButton: '更新中...',
+      autoUpdateNeverRun: '从未运行',
+      autoUpdateLastRun:
+        '上次运行：{{time}} · {{status}} · 检查 {{checked}}，更新 {{updated}}，失败 {{failed}}',
+      autoUpdateLongRunningHint:
+        '已运行较长时间。通常是 GitHub/网络较慢或某个仓库正在等待超时；可等待本次超时结束，或稍后重试。',
+      autoUpdateStalledHint:
+        '本次更新长时间没有进展，后台任务可能没有继续执行。可以现在重新更新。',
+      autoUpdateTaskStatus: '后台更新：{{status}}',
+      autoUpdateTaskOff: '未开启',
+      autoUpdateTaskReady: '已就绪',
+      autoUpdateTaskNeedsAttention: '需要处理',
+      autoUpdateTaskNeedsAttentionHint:
+        '系统定时任务未就绪。请关闭后重新开启自动更新，或查看应用日志了解原因。',
+      autoUpdateEnabled: '已开启自动更新。',
+      autoUpdateDisabled: '已关闭自动更新。',
+      autoUpdateConfigSaved: '自动更新设置已保存。',
+      autoUpdateTaskTesting: '正在启动后台更新...',
+      autoUpdateTaskTriggered: '后台更新已启动，完成后会在这里显示结果。',
+      autoUpdateErrorSummary:
+        '{{count}} 个 Skill 更新失败。处理下面的问题后，可再次立即更新。',
+      autoUpdateErrorSourceMissing:
+        '{{count}} 个本地源目录不存在。请重新关联或移除这些 Skills。',
+      autoUpdateErrorNetwork:
+        '{{count}} 个 Git 更新失败，原因是 GitHub 或网络不可访问。',
+      autoUpdateErrorRateLimited:
+        '{{count}} 个 GitHub 请求触发限流。可配置 GitHub Token 或稍后重试。',
+      autoUpdateErrorOther: '{{count}} 个更新因其他原因失败。',
+      autoUpdateViewProgress: '查看进度',
+      autoUpdateProgressTitle: '自动更新进度',
+      autoUpdateProgressTotal: '总数',
+      autoUpdateProgressSucceeded: '成功',
+      autoUpdateProgressFailed: '失败',
+      autoUpdateProgressActive: '等待/处理中',
+      autoUpdateProgressStartedAt: '开始时间',
+      autoUpdateProgressFinishedAt: '完成时间',
+      autoUpdateProgressDuration: '耗时',
+      autoUpdateProgressRunning: '当前处理',
+      autoUpdateProgressPending: '等待中',
+      autoUpdateProgressNoRunning: '当前没有正在更新的 Skill。',
+      autoUpdateProgressWaitingToStart:
+        '后台任务已启动，正在等待开始处理第一个 Skill。',
+      autoUpdateProgressNoFailed: '没有失败的 Skill。',
+      autoUpdateProgressNoSucceeded: '还没有成功更新的 Skill。',
+      autoUpdateProgressSucceededSummary: '{{count}} 个 Skill 更新成功。',
+      autoUpdateProgressPendingSummary: '{{count}} 个 Skill 等待更新。',
+      autoUpdateProgressNoPending: '没有等待中的 Skill。',
+      copyDetails: '复制详情',
+      autoUpdateStatus: {
+        none: '尚未运行',
+        running: '运行中',
+        stopped: '已停止',
+        ok: '成功',
+        error: '完成但有错误',
+      },
       downloadAndInstall: '下载并安装',
       checkingUpdates: '检查中...',
       updateNotAvailable: '已是最新版本。',


### PR DESCRIPTION
## Summary
- add user-level scheduled skill auto updates with background progress persistence
- add progress detail UI with failure details, start/finish time, and duration
- add app-level network proxy configuration for GitHub API and Git updates
- document v0.7.0 auto-update and network proxy changes

## Verification
- npm run check