### PR TITLE
fix: add Windows updater release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Build Tauri App (Windows)
         if: matrix.os == 'windows-2022'
-        # Windows 产物：只生成 NSIS 安装程序
+        # Windows updater uses the NSIS installer plus its updater signature (*.exe.sig).
         shell: bash
         run: |
           set -euo pipefail
@@ -215,7 +215,7 @@ jobs:
           echo "Arch: ${{ matrix.arch }}"
           # Add Strawberry Perl to PATH for OpenSSL build
           export PATH="/c/Strawberry/perl/bin:$PATH"
-          npm run tauri:build -- --target ${{ matrix.target }} --bundles nsis --no-sign
+          npm run tauri:build -- --target ${{ matrix.target }} --bundles nsis
           echo "=== Build completed ==="
           ls -la src-tauri/target/${{ matrix.target }}/release/bundle/ || true
 
@@ -329,8 +329,14 @@ jobs:
             exit 1
           fi
 
+          if [ ! -f "${EXE}.sig" ]; then
+            echo "❌ 未找到 Windows updater 签名文件：${EXE}.sig" >&2
+            exit 1
+          fi
+
           NEW_EXE="Skills-Hub-${VERSION}-Windows-${ARCH}.exe"
           cp "${EXE}" "release-assets/${NEW_EXE}"
+          cp "${EXE}.sig" "release-assets/${NEW_EXE}.sig"
 
       - name: List prepared assets
         shell: bash
@@ -388,6 +394,8 @@ jobs:
 
           mac_arm_url=""; mac_arm_sig=""
           mac_x64_url=""; mac_x64_sig=""
+          win_arm_url=""; win_arm_sig=""
+          win_x64_url=""; win_x64_sig=""
 
           ls -la dl || true
 
@@ -402,11 +410,15 @@ jobs:
                 mac_arm_url="$url"; mac_arm_sig="$sig_content";;
               *-macOS-x86_64.tar.gz)
                 mac_x64_url="$url"; mac_x64_sig="$sig_content";;
+              *-Windows-arm64.exe)
+                win_arm_url="$url"; win_arm_sig="$sig_content";;
+              *-Windows-x64.exe)
+                win_x64_url="$url"; win_x64_sig="$sig_content";;
             esac
           done
 
-          if [ -z "${mac_arm_url:-}" ] && [ -z "${mac_x64_url:-}" ]; then
-            echo "❌ 未找到任何 macOS updater 签名（dl/*.sig）; 请确认构建产物包含 *.tar.gz.sig" >&2
+          if [ -z "${mac_arm_url:-}" ] && [ -z "${mac_x64_url:-}" ] && [ -z "${win_arm_url:-}" ] && [ -z "${win_x64_url:-}" ]; then
+            echo "❌ 未找到任何 updater 签名（dl/*.sig）; 请确认构建产物包含 *.sig" >&2
             exit 1
           fi
 
@@ -436,6 +448,16 @@ jobs:
             if [ -n "${mac_x64_url:-}" ] && [ -n "${mac_x64_sig:-}" ]; then
               [ $first -eq 0 ] && echo ','
               echo "    \"darwin-x86_64\": {\"signature\": \"$mac_x64_sig\", \"url\": \"$mac_x64_url\"}"
+              first=0
+            fi
+            if [ -n "${win_arm_url:-}" ] && [ -n "${win_arm_sig:-}" ]; then
+              [ $first -eq 0 ] && echo ','
+              echo "    \"windows-aarch64\": {\"signature\": \"$win_arm_sig\", \"url\": \"$win_arm_url\"}"
+              first=0
+            fi
+            if [ -n "${win_x64_url:-}" ] && [ -n "${win_x64_sig:-}" ]; then
+              [ $first -eq 0 ] && echo ','
+              echo "    \"windows-x86_64\": {\"signature\": \"$win_x64_sig\", \"url\": \"$win_x64_url\"}"
               first=0
             fi
             echo '  }'

--- a/docs/releases/v0.6.3/minor-updates.md
+++ b/docs/releases/v0.6.3/minor-updates.md
@@ -13,3 +13,11 @@
 - 英文和中文工具支持列表已同步更新 Antigravity 路径。
 - 增加 Rust 回归测试，覆盖 Antigravity 全局 Skill 目录、检测目录和项目级目录映射。
 - 修复验证：`npm run check`。
+
+### 修复 Windows 自动更新平台元数据缺失
+
+- 修复 Windows 检查更新时报 `windows-x86_64` 平台缺失的问题（Issue [#78](https://github.com/qufei1993/skills-hub/issues/78)，PR [#82](https://github.com/qufei1993/skills-hub/pull/82)）。
+- Windows 发布构建恢复生成 Tauri updater 签名文件，NSIS 安装包会随 release assets 一起上传对应的 `.exe.sig`。
+- `updater.json` 生成逻辑新增 `windows-x86_64` 和 `windows-aarch64` 平台条目，分别指向 x64 与 arm64 Windows 安装包。
+- 增加发布流水线校验：缺少 Windows updater 签名文件时直接失败，避免发布缺失平台信息的 `updater.json`。
+- 修复验证：`npm run check`，并本地模拟生成 updater JSON 确认包含 macOS 与 Windows 平台键。


### PR DESCRIPTION
## Summary
- generate Windows updater signatures by building NSIS without the no-sign flag
- upload Windows .exe.sig files with release artifacts
- include windows-x86_64 and windows-aarch64 entries in updater.json

Fixes #78.

## Verification
- npm run check
- simulated updater.json generation with macOS and Windows signatures