### PR TITLE
chore: prepare v0.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-27
+
 ### Fixed
 - **Antigravity global sync path**: Updated Antigravity 2.0 global skill sync to `~/.gemini/config/skills` so synced skills are discovered by current Antigravity versions ([#79](https://github.com/qufei1993/skills-hub/issues/79)).
+- **Windows updater metadata**: Added Windows updater signatures and `windows-x86_64` / `windows-aarch64` platform entries to `updater.json`, fixing update checks on Windows ([#78](https://github.com/qufei1993/skills-hub/issues/78), [PR #82](https://github.com/qufei1993/skills-hub/pull/82)).
 
 ## [0.6.2] - 2026-06-19
 

--- a/docs/CHANGELOG.zh.md
+++ b/docs/CHANGELOG.zh.md
@@ -4,8 +4,11 @@
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-06-27
+
 ### 修复
 - **Antigravity 全局同步路径**：将 Antigravity 2.0 的全局 Skill 同步目录更新为 `~/.gemini/config/skills`，确保当前版本 Antigravity 可以发现已同步的 Skill（[#79](https://github.com/qufei1993/skills-hub/issues/79)）。
+- **Windows 自动更新元数据**：为 Windows 发布产物补充 updater 签名，并在 `updater.json` 中新增 `windows-x86_64` / `windows-aarch64` 平台条目，修复 Windows 检查更新失败的问题（[#78](https://github.com/qufei1993/skills-hub/issues/78)、[PR #82](https://github.com/qufei1993/skills-hub/pull/82)）。
 
 ## [0.6.2] - 2026-06-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skills-hub",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skills-hub",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skills-hub",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 5173 --strictPort",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.6.2"
+version = "0.6.3"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Skills Hub",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.qufei1993.skillshub",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump app versions from 0.6.2 to 0.6.3 across npm, Tauri, and Cargo metadata
- add v0.6.3 entries to English and Chinese changelogs
- verify release notes extraction for v0.6.3 before tagging

## Verification
- npm run version:check
- node scripts/extract-changelog.mjs v0.6.3 CHANGELOG.md
- npm run check

## Release note
After this PR is merged, tag v0.6.3 from the updated main branch and push the tag to trigger the release workflow.