### PR TITLE
Add Hermes Tweet to featured skills sources

### DIFF
--- a/featured-skills.json
+++ b/featured-skills.json
@@ -1,8 +1,9 @@
 {
-  "updated_at": "2026-07-01T02:01:29.897Z",
+  "updated_at": "2026-07-01T14:49:48.822Z",
   "total": 300,
   "categories": [
     "ai-assistant",
+    "browser-automation",
     "development"
   ],
   "skills": [
@@ -11,241 +12,241 @@
       "name": "algorithmic-art",
       "summary": "Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/algorithmic-art",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "brand-guidelines",
       "name": "brand-guidelines",
       "summary": "Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/brand-guidelines",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "canvas-design",
       "name": "canvas-design",
       "summary": "Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/canvas-design",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "claude-api",
       "name": "claude-api",
       "summary": "|-",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/claude-api",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "doc-coauthoring",
       "name": "doc-coauthoring",
       "summary": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/doc-coauthoring",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "docx",
       "name": "docx",
       "summary": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a 'report', 'memo', 'letter', 'template', or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/docx",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "frontend-design",
       "name": "frontend-design",
       "summary": "Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/frontend-design",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "internal-comms",
       "name": "internal-comms",
       "summary": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/internal-comms",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "mcp-builder",
       "name": "mcp-builder",
       "summary": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/mcp-builder",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "pdf",
       "name": "pdf",
       "summary": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/pdf",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "pptx",
       "name": "pptx",
       "summary": "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/pptx",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "skill-creator",
       "name": "skill-creator",
       "summary": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/skill-creator",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "slack-gif-creator",
       "name": "slack-gif-creator",
       "summary": "Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like \"make me a GIF of X doing Y for Slack.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "template",
       "name": "template-skill",
       "summary": "Replace with description of the skill and when Claude should use it.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/template",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "theme-factory",
       "name": "theme-factory",
       "summary": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/theme-factory",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "web-artifacts-builder",
       "name": "web-artifacts-builder",
       "summary": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "webapp-testing",
       "name": "webapp-testing",
       "summary": "Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/webapp-testing",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "xlsx",
       "name": "xlsx",
       "summary": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in my downloads\\\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved.",
       "downloads": 0,
-      "stars": 157024,
+      "stars": 157245,
       "category": "ai-assistant",
       "tags": [
         "agent-skills"
       ],
       "source_url": "https://github.com/anthropics/skills/tree/main/skills/xlsx",
-      "updated_at": "2026-07-01T02:00:32Z"
+      "updated_at": "2026-07-01T14:42:09Z"
     },
     {
       "slug": "00-andruia-consultant",
       "name": "00-andruia-consultant",
       "summary": "Arquitecto de Soluciones Principal y Consultor Tecnológico de Andru.ia. Diagnostica y traza la hoja de ruta óptima para proyectos de IA en español.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -255,14 +256,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/00-andruia-consultant",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "007",
       "name": "007",
       "summary": "Security audit, hardening, threat modeling (STRIDE/PASTA), Red/Blue Team, OWASP checks, code review, incident response, and infrastructure security for any project.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -272,14 +273,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/007",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "10-andruia-skill-smith",
       "name": "10-andruia-skill-smith",
       "summary": "Ingeniero de Sistemas de Andru.ia. Diseña, redacta y despliega nuevas habilidades (skills) dentro del repositorio siguiendo el Estándar de Diamante.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -289,14 +290,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/10-andruia-skill-smith",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "20-andruia-niche-intelligence",
       "name": "20-andruia-niche-intelligence",
       "summary": "Estratega de Inteligencia de Dominio de Andru.ia. Analiza el nicho específico de un proyecto para inyectar conocimientos, regulaciones y estándares únicos del sector. Actívalo tras definir el nicho.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -306,14 +307,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/20-andruia-niche-intelligence",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "2slides-ppt-generator",
       "name": "2slides-ppt-generator",
       "summary": "AI-powered presentation generation via the 2slides API — create slides from text, match a reference image style, summarize documents into decks, add AI voice narration, and export pages/audio. Use for any \\\"make slides\\\", \\\"create a deck\\\", or \\\"slides from this document\\\" request.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -323,14 +324,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/2slides-ppt-generator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "3d-web-experience",
       "name": "3d-web-experience",
       "summary": "Expert in building 3D experiences for the web - Three.js, React",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -340,14 +341,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/3d-web-experience",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ab-test-setup",
       "name": "ab-test-setup",
       "summary": "Structured guide for setting up A/B tests with mandatory gates for hypothesis, metrics, and execution readiness.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -357,14 +358,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ab-test-setup",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "ab-testing",
+      "name": "ab-testing",
+      "summary": "When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"should I test this,\"...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ab-testing",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "acceptance-orchestrator",
       "name": "acceptance-orchestrator",
       "summary": "Use when a coding task should be driven end-to-end from issue intake through implementation, review, deployment, and acceptance verification with minimal human re-intervention.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -374,14 +392,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/acceptance-orchestrator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "accessibility-compliance-accessibility-audit",
       "name": "accessibility-compliance-accessibility-audit",
       "summary": "You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers, and provide remediation guidance.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -391,14 +409,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accessibility-compliance-accessibility-audit",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "accesslint-audit",
       "name": "accesslint-audit",
       "summary": "Find and fix WCAG 2.2 accessibility issues. Two modes — report (sweep a codebase or page, produce a prioritized written report, no edits) and fix (audit→edit→verify loop on a target). Prefers direct-CDP live-DOM auditing; falls back to a browser-MCP composition or HTML-string audits.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -408,14 +426,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accesslint-audit",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "accesslint-diff",
       "name": "accesslint-diff",
       "summary": "Diff a live page's accessibility violations against a baseline — by default compares uncommitted changes (stash-based), or pass --branch [<name>] to diff against a branch. Reports only new violations introduced, violations fixed, and pre-existing count. Use `scan` for a full audit with no diffing.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -425,14 +443,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accesslint-diff",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "accesslint-scan",
       "name": "accesslint-scan",
       "summary": "Audit a live page for accessibility issues, locate each WCAG violation precisely, and return a selector-grounded fix worklist without editing.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -442,14 +460,48 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accesslint-scan",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "accint-commitments",
+      "name": "accint-commitments",
+      "summary": "Triage acc's open promises and close them with honest real-world verdicts via acc_act(runtime=\"outcome\").",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accint-commitments",
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "accint-frames",
+      "name": "accint-frames",
+      "summary": "Drain acc's deliberation queue — open/waiting brain_frames checkpointed by headless runs — via acc_act(runtime=\"continue\").",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accint-frames",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "accint-solve",
       "name": "accint-solve",
-      "summary": "Route agent work through AccInt's MCP memory loop: retrieve prior outcomes, resolve frames, and close commitments with evidence.",
+      "summary": "Route a goal through acc's scored-memory loop via acc_act(runtime=\"solve\"); deliberate any returned brain_frame and submit via continue.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -459,14 +511,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/accint-solve",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "active-directory-attacks",
       "name": "active-directory-attacks",
       "summary": "Provide comprehensive techniques for attacking Microsoft Active Directory environments. Covers reconnaissance, credential harvesting, Kerberos attacks, lateral movement, privilege escalation, and domain dominance for red team operations and penetration testing.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -476,14 +528,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/active-directory-attacks",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "activecampaign-automation",
       "name": "activecampaign-automation",
       "summary": "Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -493,14 +545,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/activecampaign-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ad-creative",
       "name": "ad-creative",
       "summary": "Create, iterate, and scale paid ad creative for Google Ads, Meta, LinkedIn, TikTok, and similar platforms. Use when generating headlines, descriptions, primary text, or large sets of ad variations for testing and performance optimization.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -510,14 +562,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ad-creative",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "add-app-clip",
+      "name": "add-app-clip",
+      "summary": "Add an iOS App Clip target to an Expo app. Use when the user mentions App Clip, AASA, apple-app-site-association, appclips, smart app banner, or wants to ship a lightweight iOS Clip invoked from a URL alongside their parent app.",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/add-app-clip",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "address-github-comments",
       "name": "address-github-comments",
       "summary": "Use when you need to address review or issue comments on an open GitHub Pull Request using the gh CLI.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -527,14 +596,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/address-github-comments",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "adhx",
       "name": "adhx",
       "summary": "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -544,14 +613,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/adhx",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "advanced-evaluation",
       "name": "advanced-evaluation",
       "summary": "This skill should be used when the user asks to \"implement LLM-as-judge\", \"compare model outputs\", \"create evaluation rubrics\", \"mitigate evaluation bias\", or mentions direct scoring, pairwise comparison, position bias, evaluation pipelines, or automated quality assessment.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -561,14 +630,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/advanced-evaluation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "advogado-criminal",
       "name": "advogado-criminal",
       "summary": "Advogado criminalista especializado em Maria da Penha, violencia domestica, feminicidio, direito penal brasileiro, medidas protetivas, inquerito policial e acao penal.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -578,14 +647,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/advogado-criminal",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "advogado-especialista",
       "name": "advogado-especialista",
       "summary": "Advogado especialista em todas as areas do Direito brasileiro: familia, criminal, trabalhista, tributario, consumidor, imobiliario, empresarial, civil e constitucional.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -595,14 +664,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/advogado-especialista",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aegisops-ai",
       "name": "aegisops-ai",
       "summary": "Autonomous DevSecOps & FinOps Guardrails. Orchestrates Gemini 3 Flash to audit Linux Kernel patches, Terraform cost drifts, and K8s compliance.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -612,14 +681,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aegisops-ai",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-creator",
       "name": "agent-creator",
       "summary": "Create custom AI subagents with proper plugin structure, persona generation, and companion routing skills.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -629,14 +698,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-creator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-evaluation",
       "name": "agent-evaluation",
       "summary": "Testing and benchmarking LLM agents including behavioral testing,",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -646,14 +715,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-evaluation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-framework-azure-ai-py",
       "name": "agent-framework-azure-ai-py",
       "summary": "Build persistent agents on Azure AI Foundry using the Microsoft Agent Framework Python SDK.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -663,14 +732,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-framework-azure-ai-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-manager-skill",
       "name": "agent-manager-skill",
       "summary": "Manage multiple local CLI agents via tmux sessions (start/stop/monitor/assign) with cron-friendly scheduling.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -680,14 +749,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-manager-skill",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "agent-memory",
+      "name": "agent-memory",
+      "summary": "A hybrid memory system that provides persistent, searchable knowledge management for AI agents.",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-memory",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-memory-mcp",
       "name": "agent-memory-mcp",
       "summary": "A hybrid memory system that provides persistent, searchable knowledge management for AI agents (Architecture, Patterns, Decisions).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -697,14 +783,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-memory-mcp",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-memory-systems",
       "name": "agent-memory-systems",
       "summary": "Memory is the cornerstone of intelligent agents. Without it, every",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -714,14 +800,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-memory-systems",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-orchestration-improve-agent",
       "name": "agent-orchestration-improve-agent",
       "summary": "Systematic improvement of existing agents through performance analysis, prompt engineering, and continuous iteration.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -731,14 +817,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-orchestration-improve-agent",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-orchestration-multi-agent-optimize",
       "name": "agent-orchestration-multi-agent-optimize",
       "summary": "Optimize multi-agent systems with coordinated profiling, workload distribution, and cost-aware orchestration. Use when improving agent performance, throughput, or reliability.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -748,14 +834,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-orchestration-multi-agent-optimize",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-orchestrator",
       "name": "agent-orchestrator",
       "summary": "Meta-skill que orquestra todos os agentes do ecossistema. Scan automatico de skills, match por capacidades, coordenacao de workflows multi-skill e registry management.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -765,14 +851,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-orchestrator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-squad",
       "name": "agent-squad",
       "summary": "Main agent orchestrator that coordinates a specialized squad of agents",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -782,14 +868,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-squad",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agent-tool-builder",
       "name": "agent-tool-builder",
       "summary": "Tools are how AI agents interact with the world. A well-designed",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -799,14 +885,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agent-tool-builder",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agentflow",
       "name": "agentflow",
       "summary": "Orchestrate autonomous AI development pipelines through your Kanban board (Asana, GitHub Projects, Linear). Manages multi-worker Claude Code dispatch, deterministic quality gates, adversarial review, per-task cost tracking, and crash-proof pipeline execution.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -816,14 +902,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agentflow",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agentfolio",
       "name": "agentfolio",
       "summary": "Skill for discovering and researching autonomous AI agents, tools, and ecosystems using the AgentFolio directory.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -833,14 +919,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agentfolio",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agentic-actions-auditor",
       "name": "agentic-actions-auditor",
       "summary": ">",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -850,14 +936,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agentic-actions-auditor",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agentmail",
       "name": "agentmail",
       "summary": "Email infrastructure for AI agents. Create accounts, send/receive emails, manage webhooks, and check karma balance via the AgentMail API.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -867,14 +953,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agentmail",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agentphone",
       "name": "agentphone",
       "summary": "Build AI phone agents with AgentPhone API. Use when the user wants to make phone calls, send/receive SMS, manage phone numbers, create voice agents, set up webhooks, or check usage — anything related to telephony, phone numbers, or voice AI.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -884,14 +970,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agentphone",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agents-md",
       "name": "agents-md",
       "summary": "This skill should be used when the user asks to \"create AGENTS.md\", \"update AGENTS.md\", \"maintain agent docs\", \"set up CLAUDE.md\", or needs to keep agent instructions concise. Enforces research-backed best practices for minimal, high-signal agent documentation.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -901,14 +987,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agents-md",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agents-v2-py",
       "name": "agents-v2-py",
       "summary": "Build container-based Foundry Agents with Azure AI Projects SDK (ImageBasedHostedAgentDefinition). Use when creating hosted agents with custom container images in Azure AI Foundry.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -918,14 +1004,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agents-v2-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "agenttrace-session-audit",
       "name": "agenttrace-session-audit",
       "summary": "Audit local AI coding-agent sessions with agenttrace for cost, tool failures, latency, anomalies, health, diffs, and CI gates.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -935,14 +1021,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/agenttrace-session-audit",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-agent-development",
       "name": "ai-agent-development",
       "summary": "AI agent development workflow for building autonomous agents, multi-agent systems, and agent orchestration with CrewAI, LangGraph, and custom agents.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -952,14 +1038,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-agent-development",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-agents-architect",
       "name": "ai-agents-architect",
       "summary": "Expert in designing and building autonomous AI agents. Masters tool",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -969,14 +1055,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-agents-architect",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-analyzer",
       "name": "ai-analyzer",
       "summary": "AI驱动的综合健康分析系统，整合多维度健康数据、识别异常模式、预测健康风险、提供个性化建议。支持智能问答和AI健康报告生成。",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -986,14 +1072,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-analyzer",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-dev-jobs-mcp",
       "name": "ai-dev-jobs-mcp",
       "summary": "Search 8,400+ AI and ML jobs across 489 companies, inspect listings and employers, match roles, and view salary and market stats via AI Dev Jobs MCP",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1003,14 +1089,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-dev-jobs-mcp",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-engineer",
       "name": "ai-engineer",
       "summary": "Build production-ready LLM applications, advanced RAG systems, and intelligent agents. Implements vector search, multimodal AI, agent orchestration, and enterprise AI integrations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1020,14 +1106,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-engineer",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-engineering-toolkit",
       "name": "ai-engineering-toolkit",
       "summary": "6 production-ready AI engineering workflows: prompt evaluation (8-dimension scoring), context budget planning, RAG pipeline design, agent security audit (65-point checklist), eval harness building, and product sense coaching.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1037,14 +1123,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-engineering-toolkit",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-loop",
       "name": "ai-loop",
       "summary": "Runs a bounded spec-build-review development loop with explicit scope, stop conditions, and human approval gates for risky or ambiguous work.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1054,14 +1140,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-loop",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-md",
       "name": "ai-md",
       "summary": "Convert human-written CLAUDE.md into AI-native structured-label format. Battle-tested across 4 models. Same rules, fewer tokens, higher compliance.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1071,14 +1157,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-md",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-ml",
       "name": "ai-ml",
       "summary": "AI and machine learning workflow covering LLM application development, RAG implementation, agent architecture, ML pipelines, and AI-powered features.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1088,14 +1174,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-ml",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-native-cli",
       "name": "ai-native-cli",
       "summary": "Design spec with 98 rules for building CLI tools that AI agents can safely use. Covers structured JSON output, error handling, input contracts, safety guardrails, exit codes, and agent self-description.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1105,14 +1191,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-native-cli",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-product",
       "name": "ai-product",
       "summary": "Every product will be AI-powered. The question is whether you'll",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1122,14 +1208,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-product",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-seo",
       "name": "ai-seo",
       "summary": "Optimize content for AI search and LLM citations across AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and similar systems. Use when improving AI visibility, answer engine optimization, or citation readiness.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1139,14 +1225,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-seo",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-studio-image",
       "name": "ai-studio-image",
       "summary": "Geracao de imagens humanizadas via Google AI Studio (Gemini). Fotos realistas estilo influencer ou educacional com iluminacao natural e imperfeicoes sutis.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1156,14 +1242,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-studio-image",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ai-wrapper-product",
       "name": "ai-wrapper-product",
       "summary": "Expert in building products that wrap AI APIs (OpenAI, Anthropic,",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1173,14 +1259,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ai-wrapper-product",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "airflow-dag-patterns",
       "name": "airflow-dag-patterns",
       "summary": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1190,14 +1276,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/airflow-dag-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "airtable-automation",
       "name": "airtable-automation",
       "summary": "Automate Airtable tasks via Rube MCP (Composio): records, bases, tables, fields, views. Always search tools first for current schemas.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1207,14 +1293,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/airtable-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "akf-trust-metadata",
       "name": "akf-trust-metadata",
       "summary": "The AI native file format. EXIF for AI — stamps every file with trust scores, source provenance, and compliance metadata. Embeds into 20+ formats (DOCX, PDF, images, code). EU AI Act, SOX, HIPAA auditing.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1224,14 +1310,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/akf-trust-metadata",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "algolia-search",
       "name": "algolia-search",
       "summary": "Expert patterns for Algolia search implementation, indexing",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1241,14 +1327,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/algolia-search",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "alpha-vantage",
       "name": "alpha-vantage",
       "summary": "Access 20+ years of global financial data: equities, options, forex, crypto, commodities, economic indicators, and 50+ technical indicators.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1258,14 +1344,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/alpha-vantage",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "alternatives-pages",
+      "name": "alternatives-pages",
+      "summary": "Create \"[Competitor] alternative\" and comparison pages for developer tools. Build honest, high-converting comparison content that ranks for competitive search terms. Trigger phrases: \"alternatives page\", \"comparison page\", \"vs page\", \"[competitor] alternative\", \"competitor comparison\",...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/alternatives-pages",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "amazon-alexa",
       "name": "amazon-alexa",
       "summary": "Integracao completa com Amazon Alexa para criar skills de voz inteligentes, transformar Alexa em assistente com Claude como cerebro (projeto Auri) e integrar com AWS ecosystem (Lambda, DynamoDB, Polly, Transcribe, Lex, Smart Home).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1275,14 +1378,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/amazon-alexa",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "amplitude-automation",
       "name": "amplitude-automation",
       "summary": "Automate Amplitude tasks via Rube MCP (Composio): events, user activity, cohorts, user identification. Always search tools first for current schemas.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1292,14 +1395,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/amplitude-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "analytics",
+      "name": "analytics",
+      "summary": "When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions \"set up tracking,\" \"GA4,\" \"Google Analytics,\" \"conversion tracking,\" \"event tracking,\" \"UTM parameters,\" \"tag manager,\" \"GTM,\" \"analytics implementation,\" \"tracking...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/analytics",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "analytics-product",
       "name": "analytics-product",
       "summary": "Analytics de produto — PostHog, Mixpanel, eventos, funnels, cohorts, retencao, north star metric, OKRs e dashboards de produto.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1309,14 +1429,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/analytics-product",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "analytics-tracking",
       "name": "analytics-tracking",
       "summary": "Design, audit, and improve analytics tracking systems that produce reliable, decision-ready data.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1326,14 +1446,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/analytics-tracking",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "analyze-project",
       "name": "analyze-project",
       "summary": "Forensic root cause analyzer for Antigravity sessions. Classifies scope deltas, rework patterns, root causes, hotspots, and auto-improves prompts/health.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1343,14 +1463,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/analyze-project",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "andrej-karpathy",
       "name": "andrej-karpathy",
       "summary": "Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1360,14 +1480,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/andrej-karpathy",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "android_ui_verification",
       "name": "android_ui_verification",
       "summary": "Automated end-to-end UI testing and verification on an Android Emulator using ADB.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1377,14 +1497,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/android_ui_verification",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "android-cli",
       "name": "android-cli",
       "summary": "Orchestrates Android development tasks including project creation, deployment, SDK management, and environment diagnostics using the `android` command-line tool.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1394,14 +1514,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/android-cli",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "android-dev",
       "name": "android-dev",
       "summary": "Production-grade Android app development guide covering native (Kotlin/Java), cross-platform (Flutter, RN, KMM), and hybrid architectures.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1411,14 +1531,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/android-dev",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "android-jetpack-compose-expert",
       "name": "android-jetpack-compose-expert",
       "summary": "Expert guidance for building modern Android UIs with Jetpack Compose, covering state management, navigation, performance, and Material Design 3.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1428,14 +1548,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/android-jetpack-compose-expert",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "android-ui-journey-testing",
       "name": "android-ui-journey-testing",
       "summary": "XML-specified Android UI journey testing, interactive step execution, assertion verification, and JSON outcome reporting.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1445,14 +1565,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/android-ui-journey-testing",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "angular",
       "name": "angular",
       "summary": "Modern Angular (v20+) expert with deep knowledge of Signals, Standalone Components, Zoneless applications, SSR/Hydration, and reactive patterns.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1462,14 +1582,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/angular",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "angular-best-practices",
       "name": "angular-best-practices",
       "summary": "Angular performance optimization and best practices guide. Use when writing, reviewing, or refactoring Angular code for optimal performance, bundle size, and rendering efficiency.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1479,14 +1599,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/angular-best-practices",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "angular-migration",
       "name": "angular-migration",
       "summary": "Master AngularJS to Angular migration, including hybrid apps, component conversion, dependency injection changes, and routing migration.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1496,14 +1616,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/angular-migration",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "angular-state-management",
       "name": "angular-state-management",
       "summary": "Master modern Angular state management with Signals, NgRx, and RxJS. Use when setting up global state, managing component stores, choosing between state solutions, or migrating from legacy patterns.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1513,14 +1633,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/angular-state-management",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "angular-ui-patterns",
       "name": "angular-ui-patterns",
       "summary": "Modern Angular UI patterns for loading states, error handling, and data display. Use when building UI components, handling async data, or managing component states.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1530,14 +1650,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/angular-ui-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "animejs-animation",
       "name": "animejs-animation",
       "summary": "Advanced JavaScript animation library skill for creating complex, high-performance web animations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1547,14 +1667,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/animejs-animation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "anti-deception",
+      "name": "anti-deception",
+      "summary": "Use BEFORE responding when the user's request shows pressure to validate or agree (\"tell them what they want\", \"make them happy\", \"convince them\"), manufactured urgency (artificial deadline), authority appeals (citing investors, advisors, lawyers, experts), demands to certify without...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/anti-deception",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "anti-reversing-techniques",
       "name": "anti-reversing-techniques",
       "summary": "AUTHORIZED USE ONLY: This skill contains dual-use security techniques. Before proceeding with any bypass or analysis: > 1.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1564,14 +1701,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/anti-reversing-techniques",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "anti-sycophancy",
       "name": "anti-sycophancy",
       "summary": "Eliminate sycophantic agreement patterns in AI responses. Load via /skill anti-sycophancy.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1581,14 +1718,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/anti-sycophancy",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "antigravity-agent-manager",
       "name": "antigravity-agent-manager",
       "summary": "Configure and orchestrate parallel agents using the standalone Antigravity 2.0 Agent Manager and Antigravity IDE.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1598,14 +1735,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/antigravity-agent-manager",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "antigravity-design-expert",
       "name": "antigravity-design-expert",
       "summary": "Core UI/UX engineering skill for building highly interactive, spatial, weightless, and glassmorphism-based web interfaces using GSAP and 3D CSS.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1615,14 +1752,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/antigravity-design-expert",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "antigravity-skill-orchestrator",
       "name": "antigravity-skill-orchestrator",
       "summary": "A meta-skill that understands task requirements, dynamically selects appropriate skills, tracks successful skill combinations using agent-memory-mcp, and prevents skill overuse for simple tasks.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1632,14 +1769,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/antigravity-skill-orchestrator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "antigravity-workflows",
       "name": "antigravity-workflows",
       "summary": "Orchestrate multiple Antigravity skills through guided workflows for SaaS MVP delivery, security audits, AI agent builds, and browser QA.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1649,14 +1786,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/antigravity-workflows",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aomi-transact",
       "name": "aomi-transact",
       "summary": "Build natural-language crypto/DeFi agents and EVM MCP plugins (Claude Code, Cursor, Codex, Gemini). Aomi turns prompts into wallet-signed txs on Ethereum, Base, Arbitrum, Optimism, Polygon, Linea — non-custodial, fork-simulated. 40+ apps: Uniswap, Aave, Lido, Morpho, GMX, Hyperliquid, Polymarket.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1666,14 +1803,48 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aomi-transact",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-analyzer",
+      "name": "api-analyzer",
+      "summary": "Validates whether an API request is correct based on provided inputs (method, URL, headers, body, auth, query params). Use this skill whenever a user wants to check, validate, debug, or verify an API call — including when they paste a curl command, show endpoint details, ask \"is this...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-analyzer",
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-and-interface-design",
+      "name": "api-and-interface-design",
+      "summary": "Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-and-interface-design",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-design-principles",
       "name": "api-design-principles",
       "summary": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers and stand the test of time.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1683,14 +1854,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-design-principles",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-designer",
+      "name": "api-designer",
+      "summary": "Generates complete, production-ready REST API endpoint specifications for any system or domain the user describes. Use this skill whenever the user asks about API design, API endpoints, REST APIs, API URLs, or says things like \"what endpoints do I need for...\", \"design an API for...\",...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-designer",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-documentation",
       "name": "api-documentation",
       "summary": "API documentation workflow for generating OpenAPI specs, creating developer guides, and maintaining comprehensive API documentation.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1700,14 +1888,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-documentation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-documentation-generator",
       "name": "api-documentation-generator",
       "summary": "Generate comprehensive, developer-friendly API documentation from code, including endpoints, parameters, examples, and best practices",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1717,14 +1905,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-documentation-generator",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-documenter",
       "name": "api-documenter",
       "summary": "Master API documentation with OpenAPI 3.1, AI-powered tools, and modern developer experience practices. Create interactive docs, generate SDKs, and build comprehensive developer portals.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1734,14 +1922,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-documenter",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-endpoint-builder",
       "name": "api-endpoint-builder",
       "summary": "Builds production-ready REST API endpoints with validation, error handling, authentication, and documentation. Follows best practices for security and scalability.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1751,14 +1939,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-endpoint-builder",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-fuzzing-bug-bounty",
       "name": "api-fuzzing-bug-bounty",
       "summary": "Provide comprehensive techniques for testing REST, SOAP, and GraphQL APIs during bug bounty hunting and penetration testing engagements. Covers vulnerability discovery, authentication bypass, IDOR exploitation, and API-specific attack vectors.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1768,14 +1956,48 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-fuzzing-bug-bounty",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-integration",
+      "name": "api-integration",
+      "summary": "Designs event-driven architectures, webhook systems, API chaining flows, ETL pipelines, and integration patterns between services. Use whenever the user asks about webhooks, event streaming, API composition, connecting two or more APIs, building pipelines, Pub/Sub, Kafka topics, ETL...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-integration",
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-onboarding",
+      "name": "api-onboarding",
+      "summary": "Reduce time-to-first-API-call (TTFAC) by optimizing every step of the developer onboarding journey. This skill covers authentication simplification, sandbox environments, interactive documentation, and identifying and eliminating common failure points. Trigger phrases: \"API...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-onboarding",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-patterns",
       "name": "api-patterns",
       "summary": "API design principles and decision-making. REST vs GraphQL vs tRPC selection, response formats, versioning, pagination.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1785,14 +2007,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "api-sdk-generator",
+      "name": "api-sdk-generator",
+      "summary": "Generates client SDK code, API wrapper libraries, request/response models, and language-specific usage patterns for any REST API. Use whenever the user asks to \"generate an SDK\", \"write a client library\", \"create API wrappers\", \"generate TypeScript types from my API\", \"write a Python...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-sdk-generator",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-security-best-practices",
       "name": "api-security-best-practices",
       "summary": "Implement secure API design patterns including authentication, authorization, input validation, rate limiting, and protection against common API vulnerabilities",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1802,14 +2041,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-security-best-practices",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-security-testing",
       "name": "api-security-testing",
       "summary": "API security testing workflow for REST and GraphQL APIs covering authentication, authorization, rate limiting, input validation, and security best practices.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1819,14 +2058,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-security-testing",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "api-testing-observability-api-mock",
       "name": "api-testing-observability-api-mock",
       "summary": "You are an API mocking expert specializing in realistic mock services for development, testing, and demos. Design mocks that simulate real API behavior and enable parallel development.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1836,14 +2075,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/api-testing-observability-api-mock",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-actor-development",
       "name": "apify-actor-development",
       "summary": "Important: Before you begin, fill in the generatedBy property in the meta section of .actor/actor.json. Replace it with the tool and model you're currently using, such as \\\"Claude Code with Claude Sonnet 4.5\\\". This helps Apify monitor and improve AGENTS.md for specific AI tools and models.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1853,14 +2092,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-actor-development",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-actorization",
       "name": "apify-actorization",
       "summary": "Actorization converts existing software into reusable serverless applications compatible with the Apify platform. Actors are programs packaged as Docker images that accept well-defined JSON input, perform an action, and optionally produce structured JSON output.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1870,14 +2109,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-actorization",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-audience-analysis",
       "name": "apify-audience-analysis",
       "summary": "Understand audience demographics, preferences, behavior patterns, and engagement quality across Facebook, Instagram, YouTube, and TikTok.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1887,14 +2126,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-audience-analysis",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-brand-reputation-monitoring",
       "name": "apify-brand-reputation-monitoring",
       "summary": "Scrape reviews, ratings, and brand mentions from multiple platforms using Apify Actors.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1904,14 +2143,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-brand-reputation-monitoring",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-competitor-intelligence",
       "name": "apify-competitor-intelligence",
       "summary": "Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1921,14 +2160,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-competitor-intelligence",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-content-analytics",
       "name": "apify-content-analytics",
       "summary": "Track engagement metrics, measure campaign ROI, and analyze content performance across Instagram, Facebook, YouTube, and TikTok.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1938,14 +2177,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-content-analytics",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-ecommerce",
       "name": "apify-ecommerce",
       "summary": "Extract product data, prices, reviews, and seller information from any e-commerce platform using Apify's E-commerce Scraping Tool.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1955,14 +2194,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-ecommerce",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-influencer-discovery",
       "name": "apify-influencer-discovery",
       "summary": "Find and evaluate influencers for brand partnerships, verify authenticity, and track collaboration performance across Instagram, Facebook, YouTube, and TikTok.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1972,14 +2211,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-influencer-discovery",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-lead-generation",
       "name": "apify-lead-generation",
       "summary": "Scrape leads from multiple platforms using Apify Actors.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -1989,14 +2228,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-lead-generation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-market-research",
       "name": "apify-market-research",
       "summary": "Analyze market conditions, geographic opportunities, pricing, consumer behavior, and product validation across Google Maps, Facebook, Instagram, Booking.com, and TripAdvisor.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2006,14 +2245,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-market-research",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-trend-analysis",
       "name": "apify-trend-analysis",
       "summary": "Discover and track emerging trends across Google Trends, Instagram, Facebook, YouTube, and TikTok to inform content strategy.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2023,14 +2262,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-trend-analysis",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apify-ultimate-scraper",
       "name": "apify-ultimate-scraper",
       "summary": "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2040,14 +2279,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apify-ultimate-scraper",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "app-builder",
       "name": "app-builder",
       "summary": "Main application building orchestrator. Creates full-stack applications from natural language requests. Determines project type, selects tech stack, coordinates agents.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2057,14 +2296,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/app-builder",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "app-store-changelog",
       "name": "app-store-changelog",
       "summary": "Generate user-facing App Store release notes from git history since the last tag.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2074,14 +2313,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/app-store-changelog",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "app-store-optimization",
       "name": "app-store-optimization",
       "summary": "Complete App Store Optimization (ASO) toolkit for researching, optimizing, and tracking mobile app performance on Apple App Store and Google Play Store",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2091,14 +2330,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/app-store-optimization",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "appdeploy",
       "name": "appdeploy",
       "summary": "Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2108,14 +2347,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/appdeploy",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "appium-skill",
+      "name": "appium-skill",
+      "summary": "Generates production-grade Appium mobile automation scripts for Android and iOS in Java, Python, or JavaScript. Supports real device and emulator testing locally and on TestMu AI cloud with 100+ real devices. Use when the user asks to automate mobile apps, test on Android/iOS, write...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/appium-skill",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "apple-notes-search",
       "name": "apple-notes-search",
       "summary": "Semantic + keyword search and connection-discovery across the user's own Apple Notes via the apple-notes MCP server. Use when the user wants to find, recall, or synthesize something from their notes, or surface non-obvious bridges/related notes. macOS, on-device.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2125,14 +2381,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/apple-notes-search",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "application-performance-performance-optimization",
       "name": "application-performance-performance-optimization",
       "summary": "Optimize end-to-end application performance with profiling, observability, and backend/frontend tuning. Use when coordinating performance optimization across the stack.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2142,14 +2398,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/application-performance-performance-optimization",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "applicationinsights-web-ts",
+      "name": "applicationinsights-web-ts",
+      "summary": "Instrument browser/web apps with the Application Insights JavaScript SDK (@microsoft/applicationinsights-web). Use for Real User Monitoring (RUM) — page views, clicks, AJAX/fetch dependencies, exceptions, custom events, and browser-side GenAI agent traces correlated to backend...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/applicationinsights-web-ts",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "architect-review",
       "name": "architect-review",
       "summary": "Master software architect specializing in modern architecture",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2159,14 +2432,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/architect-review",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "architecture",
       "name": "architecture",
       "summary": "Architectural decision-making framework. Requirements analysis, trade-off evaluation, ADR documentation. Use when making architecture decisions or analyzing system design.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2176,14 +2449,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/architecture",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "architecture-decision-records",
       "name": "architecture-decision-records",
       "summary": "Comprehensive patterns for creating, maintaining, and managing Architecture Decision Records (ADRs) that capture the context and rationale behind significant technical decisions.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2193,14 +2466,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/architecture-decision-records",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "architecture-patterns",
       "name": "architecture-patterns",
       "summary": "Master proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design to build maintainable, testable, and scalable systems.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2210,14 +2483,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/architecture-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "arm-cortex-expert",
       "name": "arm-cortex-expert",
       "summary": "Senior embedded software engineer specializing in firmware and driver development for ARM Cortex-M microcontrollers (Teensy, STM32, nRF52, SAMD).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2227,14 +2500,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/arm-cortex-expert",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "arrowspace",
       "name": "arrowspace",
       "summary": "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure in your embeddings.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2244,14 +2517,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/arrowspace",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "article-illustrations",
       "name": "article-illustrations",
       "summary": "Generate hand-drawn 16:9 article illustrations with the Grav character IP, sparse annotations, and absurd but clear visual metaphors.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2261,14 +2534,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/article-illustrations",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "asana-automation",
       "name": "asana-automation",
       "summary": "Automate Asana tasks via Rube MCP (Composio): tasks, projects, sections, teams, workspaces. Always search tools first for current schemas.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2278,14 +2551,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/asana-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ask-matt",
       "name": "ask-matt",
       "summary": "Ask which skill or flow fits your situation. A router over the user-invoked skills in this repo.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2295,14 +2568,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ask-matt",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ask-questions-if-underspecified",
       "name": "ask-questions-if-underspecified",
       "summary": "Clarify requirements before implementing. Use when serious doubts arise.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2312,14 +2585,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ask-questions-if-underspecified",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "astro",
       "name": "astro",
       "summary": "Build content-focused websites with Astro — zero JS by default, islands architecture, multi-framework components, and Markdown/MDX support.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2329,14 +2602,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/astro",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "astropy",
       "name": "astropy",
       "summary": "Astropy is the core Python package for astronomy, providing essential functionality for astronomical research and data analysis.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2346,14 +2619,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/astropy",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "async-python-patterns",
       "name": "async-python-patterns",
       "summary": "Comprehensive guidance for implementing asynchronous Python applications using asyncio, concurrent programming patterns, and async/await for building high-performance, non-blocking systems.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2363,14 +2636,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/async-python-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "atlas-contract",
       "name": "atlas-contract",
       "summary": "Goal-integrity skill. Use for backend/API/persistence, preserve/do-not-change, tests/validation, mocks, rework, multi-part requests. Emits Goal Contracts, Deviation Notices, Phase Checks, Final Audits. Skip for Q&A or trivial edits.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2380,14 +2653,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/atlas-contract",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "atlas-ledger",
       "name": "atlas-ledger",
       "summary": "Companion to atlas-contract. Auto-invoked by its Final Audit on caught drift; also use after Post Reviews or user requests to record a mistake. Distills drift into WHEN/DON'T/INSTEAD clauses, writes to Atlas.md after confirmation.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2397,14 +2670,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/atlas-ledger",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "attack-tree-construction",
       "name": "attack-tree-construction",
       "summary": "Build comprehensive attack trees to visualize threat paths. Use when mapping attack scenarios, identifying defense gaps, or communicating security risks to stakeholders.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2414,14 +2687,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/attack-tree-construction",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "audio-transcriber",
       "name": "audio-transcriber",
       "summary": "Transform audio recordings into professional Markdown documentation with intelligent summaries using LLM integration",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2431,14 +2704,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/audio-transcriber",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "audit-context-building",
       "name": "audit-context-building",
       "summary": "Enables ultra-granular, line-by-line code analysis to build deep architectural context before vulnerability or bug finding.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2448,14 +2721,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/audit-context-building",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "audit-skills",
       "name": "audit-skills",
       "summary": "Expert security auditor for AI Skills and Bundles. Performs non-intrusive static analysis to identify malicious patterns, data leaks, system stability risks, and obfuscated payloads across Windows, macOS, Linux/Unix, and Mobile (Android/iOS).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2465,14 +2738,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/audit-skills",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "auri-core",
       "name": "auri-core",
       "summary": "Auri: assistente de voz inteligente (Alexa + Claude claude-opus-4-20250805). Visao do produto, persona Vitoria Neural, stack AWS, modelo Free/Pro/Business/Enterprise, roadmap 4 fases, GTM, north star WAC e analise competitiva.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2482,14 +2755,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/auri-core",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "auth-implementation-patterns",
       "name": "auth-implementation-patterns",
       "summary": "Build secure, scalable authentication and authorization systems using industry-standard patterns and modern best practices.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2499,14 +2772,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/auth-implementation-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "automated-triage",
+      "name": "automated-triage",
+      "summary": "Triage Monte Carlo alerts interactively or build an automated workflow. Fetch, score, and troubleshoot alerts using MCP tools now, or design a reusable workflow that runs on a schedule.",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/automated-triage",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "autonomous-agent-patterns",
       "name": "autonomous-agent-patterns",
       "summary": "Design patterns for building autonomous coding agents, inspired by [Cline](https://github.com/cline/cline) and [OpenAI Codex](https://github.com/openai/codex).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2516,14 +2806,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/autonomous-agent-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "autonomous-agents",
       "name": "autonomous-agents",
       "summary": "Autonomous agents are AI systems that can independently decompose",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2533,14 +2823,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/autonomous-agents",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "avalonia-layout-zafiro",
       "name": "avalonia-layout-zafiro",
       "summary": "Guidelines for modern Avalonia UI layout using Zafiro.Avalonia, emphasizing shared styles, generic components, and avoiding XAML redundancy.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2550,14 +2840,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/avalonia-layout-zafiro",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "avalonia-viewmodels-zafiro",
       "name": "avalonia-viewmodels-zafiro",
       "summary": "Optimal ViewModel and Wizard creation patterns for Avalonia using Zafiro and ReactiveUI.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2567,14 +2857,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/avalonia-viewmodels-zafiro",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "avalonia-zafiro-development",
       "name": "avalonia-zafiro-development",
       "summary": "Mandatory skills, conventions, and behavioral rules for Avalonia UI development using the Zafiro toolkit.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2584,14 +2874,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/avalonia-zafiro-development",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "avoid-ai-writing",
       "name": "avoid-ai-writing",
       "summary": "Audit and rewrite content to remove 21 categories of AI writing patterns with a 43-entry replacement table",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2601,14 +2891,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/avoid-ai-writing",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "awareness-stage-mapper",
       "name": "awareness-stage-mapper",
       "summary": "One sentence - what this skill does and when to invoke it",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2618,14 +2908,48 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/awareness-stage-mapper",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-agentic-ai",
+      "name": "aws-agentic-ai",
+      "summary": "AWS Bedrock AgentCore comprehensive expert for deploying and managing AI agents at scale. Use when working with any AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, or Evaluations. Covers agent deployment, MCP...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-agentic-ai",
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-cdk-development",
+      "name": "aws-cdk-development",
+      "summary": "AWS Cloud Development Kit (CDK) expert for building cloud infrastructure with TypeScript/Python. Use when creating CDK stacks, defining CDK constructs, implementing infrastructure as code, or when the user mentions CDK, CloudFormation, IaC, cdk synth, cdk deploy, or wants to define AWS...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-cdk-development",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aws-cost-cleanup",
       "name": "aws-cost-cleanup",
       "summary": "Automated cleanup of unused AWS resources to reduce costs",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2635,14 +2959,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-cost-cleanup",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-cost-operations",
+      "name": "aws-cost-operations",
+      "summary": "AWS cost optimization, monitoring, and operational excellence expert. Use when analyzing AWS bills, estimating costs, setting up CloudWatch alarms, querying logs, auditing CloudTrail activity, or assessing security posture. Essential when user mentions AWS costs, spending, billing,...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-cost-operations",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aws-cost-optimizer",
       "name": "aws-cost-optimizer",
       "summary": "Comprehensive AWS cost analysis and optimization recommendations using AWS CLI and Cost Explorer",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2652,14 +2993,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-cost-optimizer",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-mcp-setup",
+      "name": "aws-mcp-setup",
+      "summary": "Configure AWS MCP servers for documentation search and API access. Use when setting up AWS MCP, configuring AWS documentation tools, troubleshooting MCP connectivity, or when user mentions aws-mcp, awsdocs, uvx setup, or MCP server configuration. Covers both Full AWS MCP Server (with...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-mcp-setup",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aws-penetration-testing",
       "name": "aws-penetration-testing",
       "summary": "Provide comprehensive techniques for penetration testing AWS cloud environments. Covers IAM enumeration, privilege escalation, SSRF to metadata endpoint, S3 bucket exploitation, Lambda code extraction, and persistence techniques for red team operations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2669,14 +3027,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-penetration-testing",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aws-serverless",
       "name": "aws-serverless",
       "summary": "Specialized skill for building production-ready serverless",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2686,14 +3044,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-serverless",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-serverless-eda",
+      "name": "aws-serverless-eda",
+      "summary": "AWS serverless and event-driven architecture expert based on Well-Architected Framework. Use when building serverless APIs, Lambda functions, REST APIs, microservices, or async workflows. Covers Lambda with TypeScript/Python, API Gateway (REST/HTTP), DynamoDB, Step Functions,...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-serverless-eda",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "aws-skills",
       "name": "aws-skills",
       "summary": "AWS development with infrastructure automation and cloud architecture patterns",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2703,14 +3078,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-skills",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "aws-sst-development",
+      "name": "aws-sst-development",
+      "summary": "SST v4 (Ion) expert for managing AWS resources as code with the Pulumi-backed framework. Use when writing or editing sst.config.ts, building infra/ modules (sst.aws.Function/Bucket/Dynamo/Cron/Service/Router, sst.Secret, sst.Linkable, raw aws.* Pulumi resources), wiring resource links,...",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/aws-sst-development",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "awt-e2e-testing",
       "name": "awt-e2e-testing",
       "summary": "AI-powered E2E web testing — eyes and hands for AI coding tools. Declarative YAML scenarios, Playwright execution, visual matching (OpenCV + OCR), platform auto-detection (Flutter/React/Vue), learning DB. Install: npx skills add ksgisang/awt-skill --skill awt -g",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2720,14 +3112,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/awt-e2e-testing",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "ax-extract-workflow",
       "name": "ax-extract-workflow",
       "summary": "Reconstruct workflow behind a past coding-agent artifact using local ax sessions/commits/skills/tool traces. Use when asked how X was built.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2737,14 +3129,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/ax-extract-workflow",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "axiom",
       "name": "axiom",
       "summary": "First-principles assumption auditor. Classifies each hidden assumption (fact / convention / belief / interest-driven), ranks by fragility × impact, and rebuilds conclusions from verified premises. Bilingual: auto-detects Chinese or English.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2754,14 +3146,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/axiom",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azd-deployment",
       "name": "azd-deployment",
       "summary": "Deploy containerized frontend + backend applications to Azure Container Apps with remote builds, managed identity, and idempotent infrastructure.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2771,14 +3163,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azd-deployment",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-agents-persistent-dotnet",
       "name": "azure-ai-agents-persistent-dotnet",
       "summary": "Azure AI Agents Persistent SDK for .NET. Low-level SDK for creating and managing AI agents with threads, messages, runs, and tools.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2788,14 +3180,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-agents-persistent-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-agents-persistent-java",
       "name": "azure-ai-agents-persistent-java",
       "summary": "Azure AI Agents Persistent SDK for Java. Low-level SDK for creating and managing AI agents with threads, messages, runs, and tools.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2805,14 +3197,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-agents-persistent-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-anomalydetector-java",
       "name": "azure-ai-anomalydetector-java",
       "summary": "Build anomaly detection applications with Azure AI Anomaly Detector SDK for Java. Use when implementing univariate/multivariate anomaly detection, time-series analysis, or AI-powered monitoring.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2822,14 +3214,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-anomalydetector-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-contentsafety-java",
       "name": "azure-ai-contentsafety-java",
       "summary": "Build content moderation applications using the Azure AI Content Safety SDK for Java.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2839,14 +3231,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-contentsafety-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-contentsafety-py",
       "name": "azure-ai-contentsafety-py",
       "summary": "Azure AI Content Safety SDK for Python. Use for detecting harmful content in text and images with multi-severity classification.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2856,14 +3248,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-contentsafety-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-contentsafety-ts",
       "name": "azure-ai-contentsafety-ts",
       "summary": "Analyze text and images for harmful content with customizable blocklists.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2873,14 +3265,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-contentsafety-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-contentunderstanding-py",
       "name": "azure-ai-contentunderstanding-py",
       "summary": "Azure AI Content Understanding SDK for Python. Use for multimodal content extraction from documents, images, audio, and video.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2890,14 +3282,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-contentunderstanding-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-document-intelligence-dotnet",
       "name": "azure-ai-document-intelligence-dotnet",
       "summary": "Azure AI Document Intelligence SDK for .NET. Extract text, tables, and structured data from documents using prebuilt and custom models.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2907,14 +3299,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-document-intelligence-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-document-intelligence-ts",
       "name": "azure-ai-document-intelligence-ts",
       "summary": "Extract text, tables, and structured data from documents using prebuilt and custom models.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2924,14 +3316,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-document-intelligence-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-formrecognizer-java",
       "name": "azure-ai-formrecognizer-java",
       "summary": "Build document analysis applications using the Azure AI Document Intelligence SDK for Java.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2941,14 +3333,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-formrecognizer-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "azure-ai-language-conversations-py",
+      "name": "azure-ai-language-conversations-py",
+      "summary": "Implement Conversational Language Understanding (CLU) using the azure-ai-language-conversations Python SDK. Use when working with ConversationAnalysisClient to analyze conversation intent and entities, building NLP features, or integrating language understanding into applications.",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-language-conversations-py",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-ml-py",
       "name": "azure-ai-ml-py",
       "summary": "Azure Machine Learning SDK v2 for Python. Use for ML workspaces, jobs, models, datasets, compute, and pipelines.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2958,14 +3367,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-ml-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-openai-dotnet",
       "name": "azure-ai-openai-dotnet",
       "summary": "Azure OpenAI SDK for .NET. Client library for Azure OpenAI and OpenAI services. Use for chat completions, embeddings, image generation, audio transcription, and assistants.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2975,14 +3384,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-openai-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-projects-dotnet",
       "name": "azure-ai-projects-dotnet",
       "summary": "Azure AI Projects SDK for .NET. High-level client for Azure AI Foundry projects including agents, connections, datasets, deployments, evaluations, and indexes.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -2992,14 +3401,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-projects-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-projects-java",
       "name": "azure-ai-projects-java",
       "summary": "Azure AI Projects SDK for Java. High-level SDK for Azure AI Foundry project management including connections, datasets, indexes, and evaluations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3009,14 +3418,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-projects-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-projects-py",
       "name": "azure-ai-projects-py",
       "summary": "Build AI applications on Microsoft Foundry using the azure-ai-projects SDK.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3026,14 +3435,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-projects-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-projects-ts",
       "name": "azure-ai-projects-ts",
       "summary": "High-level SDK for Azure AI Foundry projects with agents, connections, deployments, and evaluations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3043,14 +3452,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-projects-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-textanalytics-py",
       "name": "azure-ai-textanalytics-py",
       "summary": "Azure AI Text Analytics SDK for sentiment analysis, entity recognition, key phrases, language detection, PII, and healthcare NLP. Use for natural language processing on text.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3060,14 +3469,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-textanalytics-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-transcription-py",
       "name": "azure-ai-transcription-py",
       "summary": "Azure AI Transcription SDK for Python. Use for real-time and batch speech-to-text transcription with timestamps and diarization.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3077,14 +3486,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-transcription-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-translation-document-py",
       "name": "azure-ai-translation-document-py",
       "summary": "Azure AI Document Translation SDK for batch translation of documents with format preservation. Use for translating Word, PDF, Excel, PowerPoint, and other document formats at scale.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3094,14 +3503,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-translation-document-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-translation-text-py",
       "name": "azure-ai-translation-text-py",
       "summary": "Azure AI Text Translation SDK for real-time text translation, transliteration, language detection, and dictionary lookup. Use for translating text content in applications.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3111,14 +3520,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-translation-text-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-translation-ts",
       "name": "azure-ai-translation-ts",
       "summary": "Text and document translation with REST-style clients.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3128,14 +3537,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-translation-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-vision-imageanalysis-java",
       "name": "azure-ai-vision-imageanalysis-java",
       "summary": "Build image analysis applications with Azure AI Vision SDK for Java. Use when implementing image captioning, OCR text extraction, object detection, tagging, or smart cropping.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3145,14 +3554,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-vision-imageanalysis-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-vision-imageanalysis-py",
       "name": "azure-ai-vision-imageanalysis-py",
       "summary": "Azure AI Vision Image Analysis SDK for captions, tags, objects, OCR, people detection, and smart cropping. Use for computer vision and image understanding tasks.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3162,14 +3571,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-vision-imageanalysis-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-voicelive-dotnet",
       "name": "azure-ai-voicelive-dotnet",
       "summary": "Azure AI Voice Live SDK for .NET. Build real-time voice AI applications with bidirectional WebSocket communication.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3179,14 +3588,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-voicelive-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-voicelive-java",
       "name": "azure-ai-voicelive-java",
       "summary": "Azure AI VoiceLive SDK for Java. Real-time bidirectional voice conversations with AI assistants using WebSocket.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3196,14 +3605,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-voicelive-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-voicelive-py",
       "name": "azure-ai-voicelive-py",
       "summary": "Build real-time voice AI applications with bidirectional WebSocket communication.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3213,14 +3622,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-voicelive-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-ai-voicelive-ts",
       "name": "azure-ai-voicelive-ts",
       "summary": "Azure AI Voice Live SDK for JavaScript/TypeScript. Build real-time voice AI applications with bidirectional WebSocket communication.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3230,14 +3639,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-ai-voicelive-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-appconfiguration-java",
       "name": "azure-appconfiguration-java",
       "summary": "Azure App Configuration SDK for Java. Centralized application configuration management with key-value settings, feature flags, and snapshots.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3247,14 +3656,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-appconfiguration-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-appconfiguration-py",
       "name": "azure-appconfiguration-py",
       "summary": "Azure App Configuration SDK for Python. Use for centralized configuration management, feature flags, and dynamic settings.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3264,14 +3673,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-appconfiguration-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-appconfiguration-ts",
       "name": "azure-appconfiguration-ts",
       "summary": "Centralized configuration management with feature flags and dynamic refresh.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3281,14 +3690,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-appconfiguration-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-communication-callautomation-java",
       "name": "azure-communication-callautomation-java",
       "summary": "Build server-side call automation workflows including IVR systems, call routing, recording, and AI-powered interactions.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3298,14 +3707,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-communication-callautomation-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-communication-callingserver-java",
       "name": "azure-communication-callingserver-java",
       "summary": "⚠️ DEPRECATED: This SDK has been renamed to Call Automation. For new projects, use azure-communication-callautomation instead. This skill is for maintaining legacy code only.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3315,14 +3724,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-communication-callingserver-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-communication-chat-java",
       "name": "azure-communication-chat-java",
       "summary": "Build real-time chat applications with thread management, messaging, participants, and read receipts.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3332,14 +3741,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-communication-chat-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-communication-common-java",
       "name": "azure-communication-common-java",
       "summary": "Azure Communication Services common utilities for Java. Use when working with CommunicationTokenCredential, user identifiers, token refresh, or shared authentication across ACS services.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3349,14 +3758,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-communication-common-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-communication-sms-java",
       "name": "azure-communication-sms-java",
       "summary": "Send SMS messages with Azure Communication Services SMS Java SDK. Use when implementing SMS notifications, alerts, OTP delivery, bulk messaging, or delivery reports.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3366,14 +3775,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-communication-sms-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-compute-batch-java",
       "name": "azure-compute-batch-java",
       "summary": "Azure Batch SDK for Java. Run large-scale parallel and HPC batch jobs with pools, jobs, tasks, and compute nodes.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3383,14 +3792,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-compute-batch-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-containerregistry-py",
       "name": "azure-containerregistry-py",
       "summary": "Azure Container Registry SDK for Python. Use for managing container images, artifacts, and repositories.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3400,14 +3809,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-containerregistry-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-cosmos-db-py",
       "name": "azure-cosmos-db-py",
       "summary": "Build production-grade Azure Cosmos DB NoSQL services following clean code, security best practices, and TDD principles.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3417,14 +3826,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-cosmos-db-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-cosmos-java",
       "name": "azure-cosmos-java",
       "summary": "Azure Cosmos DB SDK for Java. NoSQL database operations with global distribution, multi-model support, and reactive patterns.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3434,14 +3843,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-cosmos-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-cosmos-py",
       "name": "azure-cosmos-py",
       "summary": "Azure Cosmos DB SDK for Python (NoSQL API). Use for document CRUD, queries, containers, and globally distributed data.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3451,14 +3860,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-cosmos-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-cosmos-rust",
       "name": "azure-cosmos-rust",
       "summary": "Azure Cosmos DB SDK for Rust (NoSQL API). Use for document CRUD, queries, containers, and globally distributed data.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3468,14 +3877,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-cosmos-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-cosmos-ts",
       "name": "azure-cosmos-ts",
       "summary": "Azure Cosmos DB JavaScript/TypeScript SDK (@azure/cosmos) for data plane operations. Use for CRUD operations on documents, queries, bulk operations, and container management.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3485,14 +3894,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-cosmos-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-data-tables-java",
       "name": "azure-data-tables-java",
       "summary": "Build table storage applications using the Azure Tables SDK for Java. Works with both Azure Table Storage and Cosmos DB Table API.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3502,14 +3911,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-data-tables-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-data-tables-py",
       "name": "azure-data-tables-py",
       "summary": "Azure Tables SDK for Python (Storage and Cosmos DB). Use for NoSQL key-value storage, entity CRUD, and batch operations.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3519,14 +3928,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-data-tables-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventgrid-dotnet",
       "name": "azure-eventgrid-dotnet",
       "summary": "Azure Event Grid SDK for .NET. Client library for publishing and consuming events with Azure Event Grid. Use for event-driven architectures, pub/sub messaging, CloudEvents, and EventGridEvents.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3536,14 +3945,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventgrid-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventgrid-java",
       "name": "azure-eventgrid-java",
       "summary": "Build event-driven applications with Azure Event Grid SDK for Java. Use when publishing events, implementing pub/sub patterns, or integrating with Azure services via events.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3553,14 +3962,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventgrid-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventgrid-py",
       "name": "azure-eventgrid-py",
       "summary": "Azure Event Grid SDK for Python. Use for publishing events, handling CloudEvents, and event-driven architectures.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3570,14 +3979,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventgrid-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventhub-dotnet",
       "name": "azure-eventhub-dotnet",
       "summary": "Azure Event Hubs SDK for .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3587,14 +3996,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventhub-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventhub-java",
       "name": "azure-eventhub-java",
       "summary": "Build real-time streaming applications with Azure Event Hubs SDK for Java. Use when implementing event streaming, high-throughput data ingestion, or building event-driven architectures.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3604,14 +4013,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventhub-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventhub-py",
       "name": "azure-eventhub-py",
       "summary": "Azure Event Hubs SDK for Python streaming. Use for high-throughput event ingestion, producers, consumers, and checkpointing.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3621,14 +4030,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventhub-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventhub-rust",
       "name": "azure-eventhub-rust",
       "summary": "Azure Event Hubs SDK for Rust. Use for sending and receiving events, streaming data ingestion.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3638,14 +4047,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventhub-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-eventhub-ts",
       "name": "azure-eventhub-ts",
       "summary": "High-throughput event streaming and real-time data ingestion.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3655,14 +4064,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-eventhub-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-functions",
       "name": "azure-functions",
       "summary": "Expert patterns for Azure Functions development including isolated",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3672,14 +4081,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-functions",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-identity-dotnet",
       "name": "azure-identity-dotnet",
       "summary": "Azure Identity SDK for .NET. Authentication library for Azure SDK clients using Microsoft Entra ID. Use for DefaultAzureCredential, managed identity, service principals, and developer credentials.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3689,14 +4098,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-identity-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-identity-java",
       "name": "azure-identity-java",
       "summary": "Authenticate Java applications with Azure services using Microsoft Entra ID (Azure AD).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3706,14 +4115,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-identity-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-identity-py",
       "name": "azure-identity-py",
       "summary": "Azure Identity SDK for Python authentication. Use for DefaultAzureCredential, managed identity, service principals, and token caching.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3723,14 +4132,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-identity-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-identity-rust",
       "name": "azure-identity-rust",
       "summary": "Azure Identity SDK for Rust authentication. Use for DeveloperToolsCredential, ManagedIdentityCredential, ClientSecretCredential, and token-based authentication.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3740,14 +4149,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-identity-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-identity-ts",
       "name": "azure-identity-ts",
       "summary": "Authenticate to Azure services with various credential types.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3757,14 +4166,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-identity-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-certificates-rust",
       "name": "azure-keyvault-certificates-rust",
       "summary": "Azure Key Vault Certificates SDK for Rust. Use for creating, importing, and managing certificates.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3774,14 +4183,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-certificates-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-keys-rust",
       "name": "azure-keyvault-keys-rust",
       "summary": "Azure Key Vault Keys SDK for Rust. Use for creating, managing, and using cryptographic keys. Triggers: \"keyvault keys rust\", \"KeyClient rust\", \"create key rust\", \"encrypt rust\", \"sign rust\".",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3791,14 +4200,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-keys-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-keys-ts",
       "name": "azure-keyvault-keys-ts",
       "summary": "Manage cryptographic keys using Azure Key Vault Keys SDK for JavaScript (@azure/keyvault-keys). Use when creating, encrypting/decrypting, signing, or rotating keys.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3808,14 +4217,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-keys-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-py",
       "name": "azure-keyvault-py",
       "summary": "Azure Key Vault SDK for Python. Use for secrets, keys, and certificates management with secure storage.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3825,14 +4234,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-secrets-rust",
       "name": "azure-keyvault-secrets-rust",
       "summary": "Azure Key Vault Secrets SDK for Rust. Use for storing and retrieving secrets, passwords, and API keys. Triggers: \"keyvault secrets rust\", \"SecretClient rust\", \"get secret rust\", \"set secret rust\".",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3842,14 +4251,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-secrets-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-keyvault-secrets-ts",
       "name": "azure-keyvault-secrets-ts",
       "summary": "Manage secrets using Azure Key Vault Secrets SDK for JavaScript (@azure/keyvault-secrets). Use when storing and retrieving application secrets or configuration values.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3859,14 +4268,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-keyvault-secrets-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-maps-search-dotnet",
       "name": "azure-maps-search-dotnet",
       "summary": "Azure Maps SDK for .NET. Location-based services including geocoding, routing, rendering, geolocation, and weather. Use for address search, directions, map tiles, IP geolocation, and weather data.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3876,14 +4285,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-maps-search-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-messaging-webpubsub-java",
       "name": "azure-messaging-webpubsub-java",
       "summary": "Build real-time web applications with Azure Web PubSub SDK for Java. Use when implementing WebSocket-based messaging, live updates, chat applications, or server-to-client push notifications.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3893,14 +4302,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-messaging-webpubsub-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-messaging-webpubsubservice-py",
       "name": "azure-messaging-webpubsubservice-py",
       "summary": "Azure Web PubSub Service SDK for Python. Use for real-time messaging, WebSocket connections, and pub/sub patterns.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3910,14 +4319,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-messaging-webpubsubservice-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-apicenter-dotnet",
       "name": "azure-mgmt-apicenter-dotnet",
       "summary": "Azure API Center SDK for .NET. Centralized API inventory management with governance, versioning, and discovery.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3927,14 +4336,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-apicenter-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-apicenter-py",
       "name": "azure-mgmt-apicenter-py",
       "summary": "Azure API Center Management SDK for Python. Use for managing API inventory, metadata, and governance across your organization.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3944,14 +4353,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-apicenter-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-apimanagement-dotnet",
       "name": "azure-mgmt-apimanagement-dotnet",
       "summary": "Azure Resource Manager SDK for API Management in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3961,14 +4370,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-apimanagement-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-apimanagement-py",
       "name": "azure-mgmt-apimanagement-py",
       "summary": "Azure API Management SDK for Python. Use for managing APIM services, APIs, products, subscriptions, and policies.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3978,14 +4387,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-apimanagement-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-applicationinsights-dotnet",
       "name": "azure-mgmt-applicationinsights-dotnet",
       "summary": "Azure Application Insights SDK for .NET. Application performance monitoring and observability resource management.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -3995,14 +4404,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-applicationinsights-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-arizeaiobservabilityeval-dotnet",
       "name": "azure-mgmt-arizeaiobservabilityeval-dotnet",
       "summary": "Azure Resource Manager SDK for Arize AI Observability and Evaluation (.NET).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4012,14 +4421,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-arizeaiobservabilityeval-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-botservice-dotnet",
       "name": "azure-mgmt-botservice-dotnet",
       "summary": "Azure Resource Manager SDK for Bot Service in .NET. Management plane operations for creating and managing Azure Bot resources, channels (Teams, DirectLine, Slack), and connection settings.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4029,14 +4438,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-botservice-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-botservice-py",
       "name": "azure-mgmt-botservice-py",
       "summary": "Azure Bot Service Management SDK for Python. Use for creating, managing, and configuring Azure Bot Service resources.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4046,14 +4455,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-botservice-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-fabric-dotnet",
       "name": "azure-mgmt-fabric-dotnet",
       "summary": "Azure Resource Manager SDK for Fabric in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4063,14 +4472,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-fabric-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-fabric-py",
       "name": "azure-mgmt-fabric-py",
       "summary": "Azure Fabric Management SDK for Python. Use for managing Microsoft Fabric capacities and resources.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4080,14 +4489,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-fabric-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-mongodbatlas-dotnet",
       "name": "azure-mgmt-mongodbatlas-dotnet",
       "summary": "Manage MongoDB Atlas Organizations as Azure ARM resources with unified billing through Azure Marketplace.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4097,14 +4506,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-mongodbatlas-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-mgmt-weightsandbiases-dotnet",
       "name": "azure-mgmt-weightsandbiases-dotnet",
       "summary": "Azure Weights & Biases SDK for .NET. ML experiment tracking and model management via Azure Marketplace. Use for creating W&B instances, managing SSO, marketplace integration, and ML observability.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4114,14 +4523,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-mgmt-weightsandbiases-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-microsoft-playwright-testing-ts",
       "name": "azure-microsoft-playwright-testing-ts",
       "summary": "Run Playwright tests at scale with cloud-hosted browsers and integrated Azure portal reporting.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4131,14 +4540,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-microsoft-playwright-testing-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-ingestion-java",
       "name": "azure-monitor-ingestion-java",
       "summary": "Azure Monitor Ingestion SDK for Java. Send custom logs to Azure Monitor via Data Collection Rules (DCR) and Data Collection Endpoints (DCE).",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4148,14 +4557,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-ingestion-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-ingestion-py",
       "name": "azure-monitor-ingestion-py",
       "summary": "Azure Monitor Ingestion SDK for Python. Use for sending custom logs to Log Analytics workspace via Logs Ingestion API.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4165,14 +4574,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-ingestion-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-opentelemetry-exporter-java",
       "name": "azure-monitor-opentelemetry-exporter-java",
       "summary": "Azure Monitor OpenTelemetry Exporter for Java. Export OpenTelemetry traces, metrics, and logs to Azure Monitor/Application Insights.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4182,14 +4591,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-opentelemetry-exporter-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-opentelemetry-exporter-py",
       "name": "azure-monitor-opentelemetry-exporter-py",
       "summary": "Azure Monitor OpenTelemetry Exporter for Python. Use for low-level OpenTelemetry export to Application Insights.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4199,14 +4608,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-opentelemetry-exporter-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-opentelemetry-py",
       "name": "azure-monitor-opentelemetry-py",
       "summary": "Azure Monitor OpenTelemetry Distro for Python. Use for one-line Application Insights setup with auto-instrumentation.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4216,14 +4625,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-opentelemetry-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-opentelemetry-ts",
       "name": "azure-monitor-opentelemetry-ts",
       "summary": "Auto-instrument Node.js applications with distributed tracing, metrics, and logs.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4233,14 +4642,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-opentelemetry-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-query-java",
       "name": "azure-monitor-query-java",
       "summary": "Azure Monitor Query SDK for Java. Execute Kusto queries against Log Analytics workspaces and query metrics from Azure resources.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4250,14 +4659,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-query-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-monitor-query-py",
       "name": "azure-monitor-query-py",
       "summary": "Azure Monitor Query SDK for Python. Use for querying Log Analytics workspaces and Azure Monitor metrics.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4267,14 +4676,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-monitor-query-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-postgres-ts",
       "name": "azure-postgres-ts",
       "summary": "Connect to Azure Database for PostgreSQL Flexible Server from Node.js/TypeScript using the pg (node-postgres) package.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4284,14 +4693,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-postgres-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-cosmosdb-dotnet",
       "name": "azure-resource-manager-cosmosdb-dotnet",
       "summary": "Azure Resource Manager SDK for Cosmos DB in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4301,14 +4710,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-cosmosdb-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-durabletask-dotnet",
       "name": "azure-resource-manager-durabletask-dotnet",
       "summary": "Azure Resource Manager SDK for Durable Task Scheduler in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4318,14 +4727,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-durabletask-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-mysql-dotnet",
       "name": "azure-resource-manager-mysql-dotnet",
       "summary": "Azure MySQL Flexible Server SDK for .NET. Database management for MySQL Flexible Server deployments.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4335,14 +4744,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-mysql-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-playwright-dotnet",
       "name": "azure-resource-manager-playwright-dotnet",
       "summary": "Azure Resource Manager SDK for Microsoft Playwright Testing in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4352,14 +4761,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-playwright-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-postgresql-dotnet",
       "name": "azure-resource-manager-postgresql-dotnet",
       "summary": "Azure PostgreSQL Flexible Server SDK for .NET. Database management for PostgreSQL Flexible Server deployments.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4369,14 +4778,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-postgresql-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-redis-dotnet",
       "name": "azure-resource-manager-redis-dotnet",
       "summary": "Azure Resource Manager SDK for Redis in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4386,14 +4795,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-redis-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-resource-manager-sql-dotnet",
       "name": "azure-resource-manager-sql-dotnet",
       "summary": "Azure Resource Manager SDK for Azure SQL in .NET.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4403,14 +4812,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-resource-manager-sql-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-search-documents-dotnet",
       "name": "azure-search-documents-dotnet",
       "summary": "Azure AI Search SDK for .NET (Azure.Search.Documents). Use for building search applications with full-text, vector, semantic, and hybrid search.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4420,14 +4829,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-search-documents-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-search-documents-py",
       "name": "azure-search-documents-py",
       "summary": "Azure AI Search SDK for Python. Use for vector search, hybrid search, semantic ranking, indexing, and skillsets.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4437,14 +4846,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-search-documents-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-search-documents-ts",
       "name": "azure-search-documents-ts",
       "summary": "Build search applications with vector, hybrid, and semantic search capabilities.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4454,14 +4863,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-search-documents-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-security-keyvault-keys-dotnet",
       "name": "azure-security-keyvault-keys-dotnet",
       "summary": "Azure Key Vault Keys SDK for .NET. Client library for managing cryptographic keys in Azure Key Vault and Managed HSM. Use for key creation, rotation, encryption, decryption, signing, and verification.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4471,14 +4880,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-security-keyvault-keys-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-security-keyvault-keys-java",
       "name": "azure-security-keyvault-keys-java",
       "summary": "Azure Key Vault Keys Java SDK for cryptographic key management. Use when creating, managing, or using RSA/EC keys, performing encrypt/decrypt/sign/verify operations, or working with HSM-backed keys.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4488,14 +4897,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-security-keyvault-keys-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-security-keyvault-secrets-java",
       "name": "azure-security-keyvault-secrets-java",
       "summary": "Azure Key Vault Secrets Java SDK for secret management. Use when storing, retrieving, or managing passwords, API keys, connection strings, or other sensitive configuration data.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4505,14 +4914,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-security-keyvault-secrets-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-servicebus-dotnet",
       "name": "azure-servicebus-dotnet",
       "summary": "Azure Service Bus SDK for .NET. Enterprise messaging with queues, topics, subscriptions, and sessions.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4522,14 +4931,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-servicebus-dotnet",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-servicebus-py",
       "name": "azure-servicebus-py",
       "summary": "Azure Service Bus SDK for Python messaging. Use for queues, topics, subscriptions, and enterprise messaging patterns.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4539,14 +4948,31 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-servicebus-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
+    },
+    {
+      "slug": "azure-servicebus-rust",
+      "name": "azure-servicebus-rust",
+      "summary": "Azure Service Bus library for Rust. Send and receive messages using queues, topics, and subscriptions. Triggers: \"service bus rust\", \"ServiceBusClient rust\", \"send message servicebus rust\", \"receive message servicebus rust\", \"queue rust messaging\", \"topic subscription rust\".",
+      "downloads": 0,
+      "stars": 42143,
+      "category": "development",
+      "tags": [
+        "agent-skills",
+        "agentic-skills",
+        "ai-agent-skills",
+        "ai-agents",
+        "ai-coding"
+      ],
+      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-servicebus-rust",
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-servicebus-ts",
       "name": "azure-servicebus-ts",
       "summary": "Enterprise messaging with queues, topics, and subscriptions.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4556,14 +4982,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-servicebus-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-speech-to-text-rest-py",
       "name": "azure-speech-to-text-rest-py",
       "summary": "Azure Speech to Text REST API for short audio (Python). Use for simple speech recognition of audio files up to 60 seconds without the Speech SDK.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4573,14 +4999,14 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-speech-to-text-rest-py",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
       "slug": "azure-storage-blob-java",
       "name": "azure-storage-blob-java",
       "summary": "Build blob storage applications using the Azure Storage Blob SDK for Java.",
       "downloads": 0,
-      "stars": 42093,
+      "stars": 42143,
       "category": "development",
       "tags": [
         "agent-skills",
@@ -4590,449 +5016,24 @@
         "ai-coding"
       ],
       "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-blob-java",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "updated_at": "2026-07-01T14:36:31Z"
     },
     {
-      "slug": "azure-storage-blob-py",
-      "name": "azure-storage-blob-py",
-      "summary": "Azure Blob Storage SDK for Python. Use for uploading, downloading, listing blobs, managing containers, and blob lifecycle.",
+      "slug": "hermes-tweet",
+      "name": "hermes-tweet",
+      "summary": "Use Xquik from Hermes Agent for X search, posting, replies, likes, retweets, follows, DMs, monitors, extraction jobs, draws, media, and trends.",
       "downloads": 0,
-      "stars": 42093,
-      "category": "development",
+      "stars": 15,
+      "category": "browser-automation",
       "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
+        "agent-skill",
+        "agent-tools",
+        "ai-agent",
+        "automation",
+        "hermes"
       ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-blob-py",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-blob-rust",
-      "name": "azure-storage-blob-rust",
-      "summary": "Azure Blob Storage SDK for Rust. Use for uploading, downloading, and managing blobs and containers.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-blob-rust",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-blob-ts",
-      "name": "azure-storage-blob-ts",
-      "summary": "Azure Blob Storage JavaScript/TypeScript SDK (@azure/storage-blob) for blob operations. Use for uploading, downloading, listing, and managing blobs and containers.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-blob-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-file-datalake-py",
-      "name": "azure-storage-file-datalake-py",
-      "summary": "Azure Data Lake Storage Gen2 SDK for Python. Use for hierarchical file systems, big data analytics, and file/directory operations.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-file-datalake-py",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-file-share-py",
-      "name": "azure-storage-file-share-py",
-      "summary": "Azure Storage File Share SDK for Python. Use for SMB file shares, directories, and file operations in the cloud.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-file-share-py",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-file-share-ts",
-      "name": "azure-storage-file-share-ts",
-      "summary": "Azure File Share JavaScript/TypeScript SDK (@azure/storage-file-share) for SMB file share operations.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-file-share-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-queue-py",
-      "name": "azure-storage-queue-py",
-      "summary": "Azure Queue Storage SDK for Python. Use for reliable message queuing, task distribution, and asynchronous processing.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-queue-py",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-storage-queue-ts",
-      "name": "azure-storage-queue-ts",
-      "summary": "Azure Queue Storage JavaScript/TypeScript SDK (@azure/storage-queue) for message queue operations. Use for sending, receiving, peeking, and deleting messages in queues.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-storage-queue-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "azure-web-pubsub-ts",
-      "name": "azure-web-pubsub-ts",
-      "summary": "Real-time messaging with WebSocket connections and pub/sub patterns.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/azure-web-pubsub-ts",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "backend-architect",
-      "name": "backend-architect",
-      "summary": "Expert backend architect specializing in scalable API design, microservices architecture, and distributed systems.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/backend-architect",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "backend-dev-guidelines",
-      "name": "backend-dev-guidelines",
-      "summary": "You are a senior backend engineer operating production-grade services under strict architectural and reliability constraints. Use when routes, controllers, services, repositories, express middleware, or prisma database access.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/backend-dev-guidelines",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "backend-development-feature-development",
-      "name": "backend-development-feature-development",
-      "summary": "Orchestrate end-to-end backend feature development from requirements to deployment. Use when coordinating multi-phase feature delivery across teams and services.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/backend-development-feature-development",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "backend-security-coder",
-      "name": "backend-security-coder",
-      "summary": "Expert in secure backend coding practices specializing in input validation, authentication, and API security. Use PROACTIVELY for backend security implementations or security code reviews.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/backend-security-coder",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "backtesting-frameworks",
-      "name": "backtesting-frameworks",
-      "summary": "Build robust, production-grade backtesting systems that avoid common pitfalls and produce reliable strategy performance estimates.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/backtesting-frameworks",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bamboohr-automation",
-      "name": "bamboohr-automation",
-      "summary": "Automate BambooHR tasks via Rube MCP (Composio): employees, time-off, benefits, dependents, employee updates. Always search tools first for current schemas.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bamboohr-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "basecamp-automation",
-      "name": "basecamp-automation",
-      "summary": "Automate Basecamp project management, to-dos, messages, people, and to-do list organization via Rube MCP (Composio). Always search tools first for current schemas.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/basecamp-automation",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "baseline-ui",
-      "name": "baseline-ui",
-      "summary": "Validates animation durations, enforces typography scale, checks component accessibility, and prevents layout anti-patterns in Tailwind CSS projects. Use when building UI components, reviewing CSS utilities, styling React views, or enforcing design consistency.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/baseline-ui",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bash-defensive-patterns",
-      "name": "bash-defensive-patterns",
-      "summary": "Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bash-defensive-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bash-linux",
-      "name": "bash-linux",
-      "summary": "Bash/Linux terminal patterns. Critical commands, piping, error handling, scripting. Use when working on macOS or Linux systems.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bash-linux",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bash-pro",
-      "name": "bash-pro",
-      "summary": "Master of defensive Bash scripting for production automation, CI/CD",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bash-pro",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bash-scripting",
-      "name": "bash-scripting",
-      "summary": "Bash scripting workflow for creating production-ready shell scripts with defensive patterns, error handling, and testing.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bash-scripting",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bats-testing-patterns",
-      "name": "bats-testing-patterns",
-      "summary": "Master Bash Automated Testing System (Bats) for comprehensive shell script testing. Use when writing tests for shell scripts, CI/CD pipelines, or requiring test-driven development of shell utilities.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bats-testing-patterns",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bazel-build-optimization",
-      "name": "bazel-build-optimization",
-      "summary": "Optimize Bazel builds for large-scale monorepos. Use when configuring Bazel, implementing remote execution, or optimizing build performance for enterprise codebases.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bazel-build-optimization",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bdi-mental-states",
-      "name": "bdi-mental-states",
-      "summary": "This skill should be used when the user asks to \"model agent mental states\", \"implement BDI architecture\", \"create belief-desire-intention models\", \"transform RDF to beliefs\", \"build cognitive agent\", or mentions BDI ontology, mental state modeling, rational agency, or neuro-symbolic AI integration.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bdi-mental-states",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bdistill-behavioral-xray",
-      "name": "bdistill-behavioral-xray",
-      "summary": "X-ray any AI model's behavioral patterns — refusal boundaries, hallucination tendencies, reasoning style, formatting defaults. No API key needed.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bdistill-behavioral-xray",
-      "updated_at": "2026-07-01T01:59:48Z"
-    },
-    {
-      "slug": "bdistill-knowledge-extraction",
-      "name": "bdistill-knowledge-extraction",
-      "summary": "Extract structured domain knowledge from AI models in-session or from local open-source models via Ollama. No API key needed.",
-      "downloads": 0,
-      "stars": 42093,
-      "category": "development",
-      "tags": [
-        "agent-skills",
-        "agentic-skills",
-        "ai-agent-skills",
-        "ai-agents",
-        "ai-coding"
-      ],
-      "source_url": "https://github.com/sickn33/antigravity-awesome-skills/tree/main/skills/bdistill-knowledge-extraction",
-      "updated_at": "2026-07-01T01:59:48Z"
+      "source_url": "https://github.com/Xquik-dev/hermes-tweet/tree/master/skills/hermes-tweet",
+      "updated_at": "2026-06-30T23:04:08Z"
     }
   ]
 }

--- a/scripts/fetch-featured-skills.mjs
+++ b/scripts/fetch-featured-skills.mjs
@@ -39,7 +39,13 @@ const CURATED_REPOS = [
   'VoltAgent/awesome-agent-skills',
   'anthropics/knowledge-work-plugins',
   'alirezarezvani/claude-skills',
+  'Xquik-dev/hermes-tweet',
 ]
+
+// Pinned curated repos stay included even if their stars would fall past the cap.
+const PINNED_REPOS = new Set([
+  'Xquik-dev/hermes-tweet',
+])
 
 const MAX_SKILLS = 300
 const CONCURRENCY = 10
@@ -347,7 +353,20 @@ async function main() {
   })
   console.log(`After dedup: ${dedupedEntries.length} unique skills (removed ${skillEntries.length - dedupedEntries.length} duplicates)`)
 
-  const topEntries = dedupedEntries.slice(0, MAX_SKILLS)
+  const pinnedEntries = []
+  const regularEntries = []
+  for (const entry of dedupedEntries) {
+    if (PINNED_REPOS.has(entry.repo.full_name)) {
+      pinnedEntries.push(entry)
+    } else {
+      regularEntries.push(entry)
+    }
+  }
+
+  const topEntries = [
+    ...pinnedEntries,
+    ...regularEntries.slice(0, Math.max(MAX_SKILLS - pinnedEntries.length, 0)),
+  ]
 
   // Step 4: Fetch SKILL.md for top skills to get real names
   console.log(`Fetching SKILL.md for ${topEntries.length} skills...`)


### PR DESCRIPTION
## Summary
- Add Xquik-dev/hermes-tweet as a curated source for the featured skills index.
- Keep pinned curated sources inside the 300-skill cap so explicitly selected low-star sources are not dropped by star sorting.
- Regenerate featured-skills.json with the existing aggregator script.

## Validation
- GITHUB_TOKEN kept in process env while running node scripts/fetch-featured-skills.mjs
- jq checked total count and the generated hermes-tweet entry
- git diff --check
- checked changed files for conflict markers and secret/private-detail terms

Note: Hermes Tweet is MIT licensed and ships a source-native skills/hermes-tweet/SKILL.md path that the existing scanner discovers.