### PR TITLE
fix(windows): junction-aware link removal + import already-managed skills

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -23,8 +23,8 @@ use crate::core::content_hash::hash_dir;
 use crate::core::featured_skills::{fetch_featured_skills, FeaturedSkill};
 use crate::core::github_search::{search_github_repos, RepoSummary};
 use crate::core::installer::{
-    install_git_skill, install_git_skill_from_selection, install_local_skill,
-    install_local_skill_from_selection, list_git_skills, list_local_skills,
+    import_existing_local_skill, install_git_skill, install_git_skill_from_selection,
+    install_local_skill, install_local_skill_from_selection, list_git_skills, list_local_skills,
     update_managed_skill_from_source, GitSkillCandidate, InstallResult, LocalSkillCandidate,
 };
 use crate::core::network_proxy::{
@@ -1416,7 +1416,7 @@ pub async fn import_existing_skill(
         if !source.join("SKILL.md").exists() {
             anyhow::bail!("SKILL_INVALID|missing_skill_md");
         }
-        let result = install_local_skill(&app, &store, source, name)?;
+        let result = import_existing_local_skill(&app, &store, source, name)?;
         Ok::<_, anyhow::Error>(to_install_dto(result))
     })
     .await

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1605,25 +1605,34 @@ pub async fn delete_managed_skill(
 
 fn remove_path_any(path: &str) -> Result<(), String> {
     let p = std::path::Path::new(path);
-    if !p.exists() {
-        return Ok(());
-    }
-
-    let meta = std::fs::symlink_metadata(p).map_err(|err| err.to_string())?;
+    // 用 symlink_metadata 而非 exists()：悬空链接（目标已删）也要清理掉
+    let meta = match std::fs::symlink_metadata(p) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(format!("{path}: {err}")),
+    };
     let ft = meta.file_type();
 
-    // 软链接（即使指向目录）也应该用 remove_file 删除链接本身
+    // 删除链接本身：Windows junction 虽然 is_symlink()==true，但它是目录型
+    // reparse point，remove_file（DeleteFileW）会报 os error 5，必须先试
+    // remove_dir（RemoveDirectoryW 只移除链接，不会穿透到目标）
     if ft.is_symlink() {
-        std::fs::remove_file(p).map_err(|err| err.to_string())?;
+        #[cfg(windows)]
+        {
+            if std::fs::remove_dir(p).is_ok() {
+                return Ok(());
+            }
+        }
+        std::fs::remove_file(p).map_err(|err| format!("{path}: {err}"))?;
         return Ok(());
     }
 
     if ft.is_dir() {
-        std::fs::remove_dir_all(p).map_err(|err| err.to_string())?;
+        std::fs::remove_dir_all(p).map_err(|err| format!("{path}: {err}"))?;
         return Ok(());
     }
 
-    std::fs::remove_file(p).map_err(|err| err.to_string())?;
+    std::fs::remove_file(p).map_err(|err| format!("{path}: {err}"))?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/tests/commands.rs
+++ b/src-tauri/src/commands/tests/commands.rs
@@ -186,6 +186,21 @@ fn remove_path_any_removes_symlink_only() {
 }
 
 #[test]
+#[cfg(windows)]
+fn remove_path_any_removes_junction_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("real");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("keep.txt"), b"keep").unwrap();
+    let link = dir.path().join("link");
+    junction::create(&target, &link).unwrap();
+
+    remove_path_any(link.to_string_lossy().as_ref()).unwrap();
+    assert!(std::fs::symlink_metadata(&link).is_err());
+    assert!(target.join("keep.txt").exists());
+}
+
+#[test]
 fn get_managed_skills_impl_maps_targets() {
     let (_dir, store) = make_store();
     let skill = SkillRecord {

--- a/src-tauri/src/core/installer.rs
+++ b/src-tauri/src/core/installer.rs
@@ -34,6 +34,25 @@ pub fn install_local_skill<R: tauri::Runtime>(
     source_path: &Path,
     name: Option<String>,
 ) -> Result<InstallResult> {
+    install_local_skill_with_existing_policy(app, store, source_path, name, false)
+}
+
+pub fn import_existing_local_skill<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    store: &SkillStore,
+    source_path: &Path,
+    name: Option<String>,
+) -> Result<InstallResult> {
+    install_local_skill_with_existing_policy(app, store, source_path, name, true)
+}
+
+fn install_local_skill_with_existing_policy<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    store: &SkillStore,
+    source_path: &Path,
+    name: Option<String>,
+    reuse_identical_existing: bool,
+) -> Result<InstallResult> {
     if !source_path.exists() {
         anyhow::bail!("source path not found: {:?}", source_path);
     }
@@ -50,21 +69,24 @@ pub fn install_local_skill<R: tauri::Runtime>(
     let central_path = central_dir.join(&name);
 
     if central_path.exists() {
-        // 中心库已有同名技能且内容一致时，视为"已纳管"：跳过复制，
-        // 返回既有记录让导入/同步流程继续（避免对工具目录里的历史副本重复导入报错）
-        let existing = store.list_skills()?.into_iter().find(|s| s.name == name);
-        let source_hash = hash_dir(source_path).ok();
-        let central_hash = hash_dir(&central_path).ok();
-        if let (Some(record), Some(src_hash), Some(dst_hash)) =
-            (existing, source_hash, central_hash)
-        {
-            if src_hash == dst_hash {
-                return Ok(InstallResult {
-                    skill_id: record.id,
-                    name: record.name,
-                    central_path,
-                    content_hash: record.content_hash,
-                });
+        if reuse_identical_existing {
+            let existing = store
+                .list_skills()?
+                .into_iter()
+                .find(|skill| Path::new(&skill.central_path) == central_path);
+            let source_hash = hash_dir(source_path).ok();
+            let central_hash = hash_dir(&central_path).ok();
+            if let (Some(record), Some(src_hash), Some(dst_hash)) =
+                (existing, source_hash, central_hash)
+            {
+                if src_hash == dst_hash {
+                    return Ok(InstallResult {
+                        skill_id: record.id,
+                        name: record.name,
+                        central_path,
+                        content_hash: record.content_hash,
+                    });
+                }
             }
         }
         anyhow::bail!("skill already exists in central repo: {:?}", central_path);

--- a/src-tauri/src/core/installer.rs
+++ b/src-tauri/src/core/installer.rs
@@ -50,6 +50,23 @@ pub fn install_local_skill<R: tauri::Runtime>(
     let central_path = central_dir.join(&name);
 
     if central_path.exists() {
+        // 中心库已有同名技能且内容一致时，视为"已纳管"：跳过复制，
+        // 返回既有记录让导入/同步流程继续（避免对工具目录里的历史副本重复导入报错）
+        let existing = store.list_skills()?.into_iter().find(|s| s.name == name);
+        let source_hash = hash_dir(source_path).ok();
+        let central_hash = hash_dir(&central_path).ok();
+        if let (Some(record), Some(src_hash), Some(dst_hash)) =
+            (existing, source_hash, central_hash)
+        {
+            if src_hash == dst_hash {
+                return Ok(InstallResult {
+                    skill_id: record.id,
+                    name: record.name,
+                    central_path,
+                    content_hash: record.content_hash,
+                });
+            }
+        }
         anyhow::bail!("skill already exists in central repo: {:?}", central_path);
     }
 

--- a/src-tauri/src/core/sync_engine.rs
+++ b/src-tauri/src/core/sync_engine.rs
@@ -198,15 +198,17 @@ pub(crate) fn remove_path_any(path: &Path) -> Result<()> {
     };
     let ft = meta.file_type();
 
-    // 软链接（即使指向目录）也应该用 remove_file 删除链接本身
+    // 删除链接本身：symlink 用 remove_file；Windows junction 虽然 is_symlink()==true，
+    // 但底层是目录 reparse point，remove_file 会报 os error 5，必须用 remove_dir
+    // （RemoveDirectoryW 只移除链接本身，不会穿透到目标）
     if ft.is_symlink() {
+        #[cfg(windows)]
+        {
+            if std::fs::remove_dir(path).is_ok() {
+                return Ok(());
+            }
+        }
         std::fs::remove_file(path).with_context(|| format!("remove symlink {:?}", path))?;
-        return Ok(());
-    }
-    // Windows junction：std 不把它归类为 symlink（is_symlink() == false），但 read_link 能解析；
-    // 必须用非递归 remove_dir 只删除链接本身，remove_dir_all 会尝试穿过 reparse point
-    if ft.is_dir() && std::fs::read_link(path).is_ok() {
-        std::fs::remove_dir(path).with_context(|| format!("remove junction {:?}", path))?;
         return Ok(());
     }
     if ft.is_dir() {

--- a/src-tauri/src/core/sync_engine.rs
+++ b/src-tauri/src/core/sync_engine.rs
@@ -76,7 +76,7 @@ pub fn sync_dir_hybrid_with_overwrite(
         }
 
         if overwrite {
-            std::fs::remove_dir_all(target)
+            remove_path_any(target)
                 .with_context(|| format!("remove existing target {:?}", target))?;
             did_replace = true;
         } else {
@@ -201,6 +201,12 @@ pub(crate) fn remove_path_any(path: &Path) -> Result<()> {
     // 软链接（即使指向目录）也应该用 remove_file 删除链接本身
     if ft.is_symlink() {
         std::fs::remove_file(path).with_context(|| format!("remove symlink {:?}", path))?;
+        return Ok(());
+    }
+    // Windows junction：std 不把它归类为 symlink（is_symlink() == false），但 read_link 能解析；
+    // 必须用非递归 remove_dir 只删除链接本身，remove_dir_all 会尝试穿过 reparse point
+    if ft.is_dir() && std::fs::read_link(path).is_ok() {
+        std::fs::remove_dir(path).with_context(|| format!("remove junction {:?}", path))?;
         return Ok(());
     }
     if ft.is_dir() {

--- a/src-tauri/src/core/tests/installer.rs
+++ b/src-tauri/src/core/tests/installer.rs
@@ -291,6 +291,50 @@ fn installs_local_skill_and_updates_from_source() {
 }
 
 #[test]
+fn imports_identical_existing_local_skill_but_rejects_different_content() {
+    let app = tauri::test::mock_app();
+    let (_dir, store) = make_store();
+    let central_root = tempfile::tempdir().unwrap();
+    set_central_path(&store, central_root.path());
+
+    let original = tempfile::tempdir().unwrap();
+    fs::write(original.path().join("SKILL.md"), b"---\nname: x\n---\n").unwrap();
+    fs::write(original.path().join("a.txt"), b"same").unwrap();
+    let installed = super::install_local_skill(
+        app.handle(),
+        &store,
+        original.path(),
+        Some("local1".to_string()),
+    )
+    .unwrap();
+
+    let discovered = tempfile::tempdir().unwrap();
+    fs::write(discovered.path().join("SKILL.md"), b"---\nname: x\n---\n").unwrap();
+    fs::write(discovered.path().join("a.txt"), b"same").unwrap();
+    let imported = super::import_existing_local_skill(
+        app.handle(),
+        &store,
+        discovered.path(),
+        Some("local1".to_string()),
+    )
+    .unwrap();
+    assert_eq!(imported.skill_id, installed.skill_id);
+    assert_eq!(imported.central_path, installed.central_path);
+
+    fs::write(discovered.path().join("a.txt"), b"different").unwrap();
+    let err = match super::import_existing_local_skill(
+        app.handle(),
+        &store,
+        discovered.path(),
+        Some("local1".to_string()),
+    ) {
+        Ok(_) => panic!("expected error"),
+        Err(err) => err,
+    };
+    assert!(format!("{err:#}").contains("skill already exists"));
+}
+
+#[test]
 fn lists_and_installs_git_skills_without_network() {
     let app = tauri::test::mock_app();
     let (_dir, store) = make_store();

--- a/src-tauri/src/core/tests/sync_engine.rs
+++ b/src-tauri/src/core/tests/sync_engine.rs
@@ -115,6 +115,25 @@ fn explicit_junction_mode_reports_unsupported_platform() {
     assert!(err.to_string().contains("junction not supported"));
 }
 
+#[cfg(windows)]
+#[test]
+fn overwrite_removes_junction_without_removing_its_target() {
+    let source = tempfile::tempdir().unwrap();
+    fs::write(source.path().join("source.txt"), b"source").unwrap();
+
+    let target_root = tempfile::tempdir().unwrap();
+    let junction_target = target_root.path().join("junction-target");
+    fs::create_dir_all(&junction_target).unwrap();
+    fs::write(junction_target.join("keep.txt"), b"keep").unwrap();
+
+    let target = target_root.path().join("target");
+    junction::create(&junction_target, &target).unwrap();
+
+    let out = sync_dir_hybrid_with_overwrite(source.path(), &target, true).unwrap();
+    assert!(out.replaced);
+    assert!(junction_target.join("keep.txt").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn copy_overwrite_replaces_broken_symlink_target() {


### PR DESCRIPTION
## Problem (Windows)
1. Disabling/unsyncing/deleting a skill synced as a **directory junction** failed with `拒绝访问。(os error 5)` (Access Denied). Affected the master toggle, per-tool unsync, and skill deletion.
2. Importing discovered stray copies that already exist in the central repo (even byte-identical) errored for every skill.

## Root cause (verified empirically, Win11 / Rust 1.95)
- A junction reports `symlink_metadata().file_type().is_symlink() == true` (and `is_dir() == false`).
- `std::fs::remove_file` (DeleteFileW) cannot delete a directory reparse point -> os error 5.
- `std::fs::remove_dir` (RemoveDirectoryW) removes the link itself without touching the target.
- **Extra twist:** `commands/mod.rs` defined its own `remove_path_any(&str)` that shadowed the patched `sync_engine::remove_path_any` - the toggle/unsync/delete flows all used the unpatched copy. Fixed in def3ffc.

## Fix
- `sync_engine::remove_path_any`: for symlink-type entries on Windows try `remove_dir` first (junction), fall back to `remove_file` (plain symlinks).
- `commands::remove_path_any` (shadowed copy used by unsync/enable-toggle/delete): same junction-aware removal; also uses `symlink_metadata` instead of `exists()` so dangling links are cleaned too; errors now include the path.
- `sync_dir_hybrid_with_overwrite`: replace `remove_dir_all` with `remove_path_any` (avoid recursing through a reparse point).
- `install_local_skill`: identical-content central skills return the existing record instead of erroring.

## Testing
- Reproduced os error 5 with the exact remove_file call on a junction; verified remove_dir removes only the link.
- Built and used daily on Windows 11 (86 skills / 16 tool targets): toggle/unsync/delete/import verified.
