### PR TITLE
fix: disable Add Skill action until a source is provided

### DIFF
--- a/src/components/skills/modals/AddSkillModal.test.tsx
+++ b/src/components/skills/modals/AddSkillModal.test.tsx
@@ -1,0 +1,70 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { TFunction } from 'i18next'
+import { describe, expect, it, vi } from 'vitest'
+import AddSkillModal from './AddSkillModal'
+
+const translate = ((key: string) => key) as TFunction
+
+const renderModal = ({
+  addModalTab,
+  localPath = '',
+  gitUrl = '',
+}: {
+  addModalTab: 'local' | 'git'
+  localPath?: string
+  gitUrl?: string
+}) =>
+  renderToStaticMarkup(
+    <AddSkillModal
+      open
+      loading={false}
+      canClose
+      addModalTab={addModalTab}
+      localPath={localPath}
+      gitUrl={gitUrl}
+      tags={[]}
+      selectedTagIds={[]}
+      syncTargets={{}}
+      installedTools={[]}
+      toolStatus={null}
+      installScope="global"
+      installProjects={[]}
+      recentProjects={[]}
+      onRequestClose={vi.fn()}
+      onTabChange={vi.fn()}
+      onLocalPathChange={vi.fn()}
+      onPickLocalPath={vi.fn()}
+      onGitUrlChange={vi.fn()}
+      onToggleTag={vi.fn()}
+      onSyncTargetChange={vi.fn()}
+      onInstallScopeChange={vi.fn()}
+      onInstallProjectsChange={vi.fn()}
+      onPickProject={vi.fn()}
+      onSubmit={vi.fn()}
+      t={translate}
+    />,
+  )
+
+describe('AddSkillModal source validation', () => {
+  it.each([
+    ['git', { gitUrl: '   ' }],
+    ['local', { localPath: '   ' }],
+  ] as const)('disables the %s action while its source is blank', (addModalTab, source) => {
+    const markup = renderModal({ addModalTab, ...source })
+
+    expect(markup).toMatch(
+      /<button class="btn btn-primary" disabled="">(?:install|create)<\/button>/,
+    )
+  })
+
+  it.each([
+    ['git', { gitUrl: 'https://github.com/example/skill.git' }],
+    ['local', { localPath: '/tmp/example-skill' }],
+  ] as const)('enables the %s action when its source is present', (addModalTab, source) => {
+    const markup = renderModal({ addModalTab, ...source })
+
+    expect(markup).toMatch(
+      /<button class="btn btn-primary">(?:install|create)<\/button>/,
+    )
+  })
+})

--- a/src/components/skills/modals/AddSkillModal.tsx
+++ b/src/components/skills/modals/AddSkillModal.tsx
@@ -73,6 +73,8 @@ const AddSkillModal = ({
   const projectRequired =
     installScope === 'project' &&
     normalizeProjectPaths(installProjects).length === 0
+  const sourceRequired =
+    (addModalTab === 'local' ? localPath : gitUrl).trim().length === 0
   const unsupportedTools = getUnsupportedToolsForScope(
     installedTools,
     installScope,
@@ -326,7 +328,7 @@ const AddSkillModal = ({
                 <button
                   className="btn btn-primary"
                   onClick={onSubmit}
-                  disabled={loading || projectRequired}
+                  disabled={loading || projectRequired || sourceRequired}
                 >
                   {addModalTab === 'local' ? t('create') : t('install')}
                 </button>


### PR DESCRIPTION
## Summary

- disable the Git install action while the repository URL is blank or whitespace-only
- disable the local create action while the folder path is blank or whitespace-only
- keep the existing submit-handler validation as defense in depth
- add focused coverage for blank and non-empty source states on both tabs

## Why

The Add Skill dialog currently renders its primary action as available before the required source is present. Clicking it only reaches the existing validation error. Matching the button state to the prerequisite removes a misleading affordance and follows the dialog's existing project-scope validation pattern.

## Verification

- `npm test -- --run src/components/skills/modals/AddSkillModal.test.tsx` — 4 passed
- `npm run check` — 8 frontend test files / 52 tests passed; TypeScript/Vite build passed; Rust fmt and clippy passed; 146 Rust tests passed
- Runtime macOS check: blank Git source rendered the action disabled; entering a non-empty source enabled it; no install was submitted

## UI states

| Source input | Primary action |
| --- | --- |
| Empty or whitespace-only | Disabled |
| Non-empty | Enabled, unless loading or project scope still lacks a project |